### PR TITLE
Instance ingest update

### DIFF
--- a/alembic/versions/06250c05785b_add_generic_identifier_table.py
+++ b/alembic/versions/06250c05785b_add_generic_identifier_table.py
@@ -1,0 +1,29 @@
+"""Add generic identifier table
+
+Revision ID: 06250c05785b
+Revises: 87c0e214bba1
+Create Date: 2019-01-08 12:26:19.054744
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '06250c05785b'
+down_revision = '87c0e214bba1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'generic',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value', sa.Unicode, nullable=False, index=True),
+        sa.Column('identifier_id', sa.Integer, sa.ForeignKey('identifiers.id'))
+    )
+
+
+def downgrade():
+    op.drop_table('generic')

--- a/alembic/versions/1ec33478ad90_add_license_and_rights_statement_fields_.py
+++ b/alembic/versions/1ec33478ad90_add_license_and_rights_statement_fields_.py
@@ -1,0 +1,30 @@
+"""Add license and rights_statement fields to instances
+
+Revision ID: 1ec33478ad90
+Revises: d4b6e9caf603
+Create Date: 2019-01-08 18:37:24.100668
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1ec33478ad90'
+down_revision = 'd4b6e9caf603'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('instances',
+        sa.Column('license', sa.String(255), nullable=True)
+    )
+    op.add_column('instances',
+        sa.Column('rights_statement', sa.Unicode, nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('instances', 'license')
+    op.drop_column('instances', 'rights_statement')

--- a/alembic/versions/594957f8b6cc_fix_extant_typo.py
+++ b/alembic/versions/594957f8b6cc_fix_extant_typo.py
@@ -1,0 +1,24 @@
+"""Fix extant typo
+
+Revision ID: 594957f8b6cc
+Revises: 1ec33478ad90
+Create Date: 2019-01-09 13:25:26.301464
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '594957f8b6cc'
+down_revision = '1ec33478ad90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('instances', 'extant', new_column_name='extent')
+
+
+def downgrade():
+    op.alter_column('instances', 'extent', new_column_name='extant')

--- a/alembic/versions/87c0e214bba1_add_extant_and_alt_titles_to_instance_.py
+++ b/alembic/versions/87c0e214bba1_add_extant_and_alt_titles_to_instance_.py
@@ -1,0 +1,51 @@
+"""Add extant and alt_titles to instance table
+
+Revision ID: 87c0e214bba1
+Revises: f0645598beea
+Create Date: 2019-01-08 10:26:57.927739
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '87c0e214bba1'
+down_revision = 'f0645598beea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('instances',
+        sa.Column('extant', sa.Unicode(), nullable=True)
+    )
+    op.drop_column('instances', 'alt_title')
+    op.drop_column('alt_titles', 'work_id')
+
+    op.create_table(
+        'work_alt_titles',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('work_id', sa.Integer, sa.ForeignKey('works.id')),
+        sa.Column('title_id', sa.Integer, sa.ForeignKey('alt_titles.id'))
+    )
+
+    op.create_table(
+        'instance_alt_titles',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('instance_id', sa.Integer, sa.ForeignKey('instances.id')),
+        sa.Column('title_id', sa.Integer, sa.ForeignKey('alt_titles.id'))
+    )
+
+
+def downgrade():
+    op.drop_column('instances', 'extant')
+    op.add_column('instances',
+        sa.Column('alt_title', sa.Unicode(), nullable=True)
+    )
+    op.add_column('alt_titles',
+        sa.Column('work_id', sa.Integer, sa.ForeignKey('works.id'))
+    )
+
+    op.drop_table('work_alt_titles')
+    op.drop_table('instance_alt_titles')

--- a/alembic/versions/d4b6e9caf603_increase_length_of_url_field_in_links_.py
+++ b/alembic/versions/d4b6e9caf603_increase_length_of_url_field_in_links_.py
@@ -1,0 +1,24 @@
+"""Increase length of URL field in links table
+
+Revision ID: d4b6e9caf603
+Revises: d8506b1d5654
+Create Date: 2019-01-08 13:54:35.393325
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd4b6e9caf603'
+down_revision = 'd8506b1d5654'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('links', 'url', type_=sa.String(255))
+
+
+def downgrade():
+    op.alter_column('links', 'url', type_=sa.String(125))

--- a/alembic/versions/d8506b1d5654_add_date_created_date_modified_to_new_.py
+++ b/alembic/versions/d8506b1d5654_add_date_created_date_modified_to_new_.py
@@ -1,0 +1,82 @@
+"""Add date_created, date_modified to new tables
+
+Revision ID: d8506b1d5654
+Revises: 06250c05785b
+Create Date: 2019-01-08 13:46:07.108377
+
+"""
+from datetime import datetime
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd8506b1d5654'
+down_revision = '06250c05785b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('generic',
+        sa.Column(
+            'date_created',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+    op.add_column('generic',
+        sa.Column(
+            'date_modified',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+    op.add_column('work_alt_titles',
+        sa.Column(
+            'date_created',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+    op.add_column('work_alt_titles',
+        sa.Column(
+            'date_modified',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+    op.add_column('instance_alt_titles',
+        sa.Column(
+            'date_created',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+    op.add_column('instance_alt_titles',
+        sa.Column(
+            'date_modified',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+
+
+def downgrade():
+    op.drop_column('generic', 'date_created')
+    op.drop_column('generic', 'date_modified')
+    op.drop_column('work_alt_titles', 'date_created')
+    op.drop_column('work_alt_titles', 'date_modified')
+    op.drop_column('instance_alt_titles', 'date_created')
+    op.drop_column('instance_alt_titles', 'date_modified')

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 region: us-east-1
 
-function_name: sfr-db-manager
+function_name: sfr-db-manager-development
 handler: service.handler
-description:
+description: Manages updates to SFR database for work, instance, item and report records
 runtime: python3.6
-role:
+role: lambda_basic_execution
 
 # if access key and secret are left blank, boto will use the credentials
 # defined in the [default] section of ~/.aws/credentials.

--- a/helpers/errorHelpers.py
+++ b/helpers/errorHelpers.py
@@ -14,7 +14,13 @@ class OutputError(Exception):
     def __init__(self, message):
         self.message = message
 
+
 class DBError(Exception):
     def __init__(self, table, message):
         self.table = table
+        self.message = message
+
+
+class DataError(Exception):
+    def __init__(self, message):
         self.message = message

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -90,6 +90,10 @@ def importRecord(session, record):
 
         dbInstance = Instance.updateOrInsert(session, instanceData)
 
+        if dbInstance is not None:
+            logger.warning('Could not find existing record for instance {}'.format(dbInstance.id))
+        
+
     elif record['type'] == 'item':
         logger.info('Ingesting item record')
         itemData = record['data']

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -84,6 +84,12 @@ def importRecord(session, record):
 
         return op, dbWork.uuid.hex
 
+    elif record['type'] == 'instance':
+        logger.info('Ingesting instance record')
+        instanceData = record['data']
+
+        dbInstance = Instance.updateOrInsert(session, instanceData)
+
     elif record['type'] == 'item':
         logger.info('Ingesting item record')
         itemData = record['data']

--- a/model/altTitle.py
+++ b/model/altTitle.py
@@ -9,15 +9,36 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from model.core import Base, Core
 
+WORK_ALTS = Table(
+    'work_alt_titles',
+    Base.metadata,
+    Column('work_id', Integer, ForeignKey('works.id')),
+    Column('title_id', Integer, ForeignKey('alt_titles.id'))
+)
+
+INSTANCE_ALTS = Table(
+    'instance_alt_titles',
+    Base.metadata,
+    Column('instance_id', Integer, ForeignKey('instances.id')),
+    Column('title_id', Integer, ForeignKey('alt_titles.id'))
+)
 
 class AltTitle(Core, Base):
     """Contains alternate titles for works"""
     __tablename__ = 'alt_titles'
     id = Column(Integer, primary_key=True)
     title = Column(Unicode, index=True)
-    work_id = Column(Integer, ForeignKey('works.id'))
 
-    work = relationship('Work', back_populates='alt_titles')
+    works = relationship(
+        'Work',
+        secondary=WORK_ALTS,
+        back_populates='links'
+    )
+    instances = relationship(
+        'Instance',
+        secondary=INSTANCE_ALTS,
+        back_populates='links'
+    )
 
     def __repr__(self):
         return '<AltTitle(title={}, work={})>'.format(self.title, self.work)

--- a/model/altTitle.py
+++ b/model/altTitle.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (
+    Table,
     Column,
     ForeignKey,
     Integer,
@@ -29,15 +30,15 @@ class AltTitle(Core, Base):
     id = Column(Integer, primary_key=True)
     title = Column(Unicode, index=True)
 
-    works = relationship(
+    work = relationship(
         'Work',
         secondary=WORK_ALTS,
-        back_populates='links'
+        back_populates='alt_titles'
     )
-    instances = relationship(
+    instance = relationship(
         'Instance',
         secondary=INSTANCE_ALTS,
-        back_populates='links'
+        back_populates='alt_titles'
     )
 
     def __repr__(self):

--- a/model/core.py
+++ b/model/core.py
@@ -20,6 +20,6 @@ class Core(object):
         onupdate=datetime.now()
     )
 
-    def updateFields(self, **kwargs)
+    def updateFields(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/model/core.py
+++ b/model/core.py
@@ -19,3 +19,7 @@ class Core(object):
         default=datetime.now(),
         onupdate=datetime.now()
     )
+
+    def updateFields(self, **kwargs)
+        for key, value in kwargs.items():
+            setattr(self, key, value)

--- a/model/identifiers.py
+++ b/model/identifiers.py
@@ -156,7 +156,7 @@ class GENERIC(Core, Base):
 
     identifier_id = Column(Integer, ForeignKey('identifiers.id'))
 
-    identifier = relationship('Identifier', back_populates='ddc')
+    identifier = relationship('Identifier', back_populates='generic')
 
     def __repr__(self):
         return '<GENERIC(value={})>'.format(self.value)
@@ -244,7 +244,8 @@ class Identifier(Base):
         idenRec = specificIden(value=identifier['identifier'])
 
         # Add new identifier entry to the core table record
-        idenField = getattr(coreIden, identifier['type'])
+        idenTable = identifier['type'] if identifier['type'] is not None else 'generic'
+        idenField = getattr(coreIden, idenTable)
         idenField.append(idenRec)
 
         return coreIden
@@ -282,8 +283,9 @@ class Identifier(Base):
                 ident['type']
             ))
             idenType = ident['type']
+            idenTable = idenType if idenType is not None else 'generic'
             existing = session.query(model)\
-                .join('identifiers', idenType)\
+                .join('identifiers', idenTable)\
                 .filter(cls.identifierTypes[idenType].value == ident['identifier'])\
                 .all()
 

--- a/model/identifiers.py
+++ b/model/identifiers.py
@@ -148,6 +148,20 @@ class DDC(Core, Base):
         return '<DDC(value={})>'.format(self.value)
 
 
+class GENERIC(Core, Base):
+    """Table for generic or otherwise uncontroller identifiers"""
+    __tablename__ = 'generic'
+    id = Column(Integer, primary_key=True)
+    value = Column(Unicode, index=True)
+
+    identifier_id = Column(Integer, ForeignKey('identifiers.id'))
+
+    identifier = relationship('Identifier', back_populates='ddc')
+
+    def __repr__(self):
+        return '<GENERIC(value={})>'.format(self.value)
+
+
 class Identifier(Base):
     """Core table for Identifiers. This relates specific identifiers, each
     contained within their own table, to FRBR entities. This structure allows
@@ -182,6 +196,7 @@ class Identifier(Base):
     owi = relationship('OWI', back_populates='identifier')
     lcc = relationship('LCC', back_populates='identifier')
     ddc = relationship('DDC', back_populates='identifier')
+    generic = relationship('GENERIC', back_populates='identifier')
 
     identifierTypes = {
         'gutenberg': Gutenberg,
@@ -191,7 +206,8 @@ class Identifier(Base):
         'isbn': ISBN,
         'issn': ISSN,
         'lcc': LCC,
-        'ddc': DDC
+        'ddc': DDC,
+        None: GENERIC
     }
 
     def __repr__(self):

--- a/model/instance.py
+++ b/model/instance.py
@@ -88,8 +88,19 @@ class Instance(Core, Base):
         measurements = instance.pop('measurements', None)
         links = instance.pop('links', None)
         alt_titles = instance.pop('alt_titles', None)
+
+        # Get fields targeted for works
+        series = instance.pop('series', None)
+        seriesPos = instance.pop('series_position', None)
+
+
         existing = Identifier.getByIdentifier(Instance, session, identifiers)
         if existing is not None:
+            parentWork = session.query(Work).get(existing.work_id)
+            parentWork.updateFields(**{
+                'series': series,
+                'series_position': seriesPos
+            })
             Instance.update(
                 session,
                 existing,

--- a/model/instance.py
+++ b/model/instance.py
@@ -122,6 +122,8 @@ class Instance(Core, Base):
         measurements = kwargs.get('measurements', [])
         items = kwargs.get('items', [])
         agents = kwargs.get('agents', [])
+        altTitles = kwargs.get('alt_titles', [])
+        links = kwargs.get('links', [])
 
         if len(instance['language']) != 2:
             lang = babelfish.Language(instance['language'])
@@ -166,6 +168,14 @@ class Instance(Core, Base):
                         role=role
                     )
 
+        for altTitle in list(filter(lambda x: AltTitle.insertOrSkip(session, x, Instance, existing.id), altTitles)):
+            existing.altTitles.append(AltTitle(title=altTitle))
+
+        for link in links:
+            updateLink = Link.updateOrInsert(session, link, Instance, existing.id)
+            if updateLink is not None:
+                existing.links.append(updateLink)
+
         return existing
 
     @classmethod
@@ -182,6 +192,8 @@ class Instance(Core, Base):
         measurements = kwargs.get('measurements', [])
         items = kwargs.get('items', [])
         agents = kwargs.get('agents', [])
+        altTitles = kwargs.get('alt_titles', [])
+        links = kwargs.get('links', [])
 
         if agents is not None:
             for agent in agents:
@@ -201,6 +213,13 @@ class Instance(Core, Base):
         for measurement in measurements:
             measurementRec = Measurement.insert(measurement)
             instance.measurements.append(measurementRec)
+
+        for altTitle in altTitles:
+            instance.altTitles.append(AltTitle(title=altTitle))
+
+        for link in links:
+            newLink = Link(**link)
+            work.links.append(newLink)
 
         # We need to get the ID of the instance to allow for asynchronously
         # storing the ePub file, so instance is added and flushed here

--- a/model/instance.py
+++ b/model/instance.py
@@ -36,6 +36,8 @@ class Instance(Core, Base):
     copyright_date = Column(Date, index=True)
     language = Column(String(2), index=True)
     extant = Column(Unicode)
+    license = Column(String(255))
+    rights_statement = Column(Unicode)
 
     work_id = Column(Integer, ForeignKey('works.id'))
 

--- a/model/instance.py
+++ b/model/instance.py
@@ -161,11 +161,11 @@ class Instance(Core, Base):
             existing.measurements.append(measurementRec)
 
         for item in items:
-            # TODO This should defer and put this into a stream for
-            # processing/storage
-            Item.createLocalEpub(item, existing.id)
-            # itemRec = Item.updateOrInsert(session, item)
-            # existing.items.append(itemRec)
+            # Check if the provided record contains an epub that can be stored
+            # locally. If it does, defer insert to epub creation process
+            itemRes = Item.createOrStore(session, item, existing.id)
+            if itemRes is not None:
+                existing.items.append(itemRec)
 
         for agent in agents:
             agentRec, roles = Agent.updateOrInsert(session, agent)
@@ -239,9 +239,9 @@ class Instance(Core, Base):
         session.flush()
 
         for item in items:
-            Item.createLocalEpub(item, instance.id)
-            # itemRec = Item.updateOrInsert(session, item)
-            # instance.items.append(itemRec)
+            itemRes = Item.createOrStore(session, item, existing.id)
+            if item is not None:
+                instance.items.append(itemRec)
 
         return instance
 

--- a/model/instance.py
+++ b/model/instance.py
@@ -16,6 +16,7 @@ from model.identifiers import INSTANCE_IDENTIFIERS, Identifier
 from model.link import INSTANCE_LINKS
 from model.item import Item
 from model.agent import Agent
+from model.altTitle import INSTANCE_ALTS
 
 
 class Instance(Core, Base):
@@ -26,7 +27,6 @@ class Instance(Core, Base):
     id = Column(Integer, primary_key=True)
     title = Column(Unicode, index=True)
     sub_title = Column(Unicode, index=True)
-    alt_title = Column(Unicode, index=True)
     pub_place = Column(Unicode, index=True)
     pub_date = Column(Date, index=True)
     edition = Column(Unicode)
@@ -34,6 +34,7 @@ class Instance(Core, Base):
     table_of_contents = Column(Unicode)
     copyright_date = Column(Date, index=True)
     language = Column(String(2), index=True)
+    extant = Column(Unicode)
 
     work_id = Column(Integer, ForeignKey('works.id'))
 
@@ -64,6 +65,11 @@ class Instance(Core, Base):
         secondary=INSTANCE_LINKS,
         back_populates='instances'
     )
+    alt_titles = relationship(
+        'AltTitle',
+        secondary=INSTANCE_ALTS
+        back_populates='work'
+    )
 
     def __repr__(self):
         return '<Instance(title={}, edition={}, work={})>'.format(
@@ -80,6 +86,8 @@ class Instance(Core, Base):
         agents = instance.pop('agents', None)
         identifiers = instance.pop('identifiers', None)
         measurements = instance.pop('measurements', None)
+        links = instance.pop('links', None)
+        alt_titles = instance.pop('alt_titles', None)
         existing = Identifier.getByIdentifier(Instance, session, identifiers)
         if existing is not None:
             Instance.update(
@@ -89,7 +97,9 @@ class Instance(Core, Base):
                 items=items,
                 agents=agents,
                 identifiers=identifiers,
-                measurements=measurements
+                measurements=measurements,
+                links=links,
+                alt_titles=alt_titles
             )
             return None
 
@@ -99,7 +109,9 @@ class Instance(Core, Base):
             items=items,
             agents=agents,
             identifiers=identifiers,
-            measurements=measurements
+            measurements=measurements,
+            links=links,
+            alt_titles=alt_titles
         )
         return newInstance
 

--- a/model/instance.py
+++ b/model/instance.py
@@ -35,7 +35,7 @@ class Instance(Core, Base):
     table_of_contents = Column(Unicode)
     copyright_date = Column(Date, index=True)
     language = Column(String(2), index=True)
-    extant = Column(Unicode)
+    extent = Column(Unicode)
     license = Column(String(255))
     rights_statement = Column(Unicode)
 
@@ -89,7 +89,7 @@ class Instance(Core, Base):
         agents = instance.pop('agents', None)
         identifiers = instance.pop('identifiers', None)
         measurements = instance.pop('measurements', None)
-        links = instance.pop('links', None)
+        links = instance.pop('links', [])
         alt_titles = instance.pop('alt_titles', None)
 
         # Get fields targeted for works
@@ -247,7 +247,7 @@ class Instance(Core, Base):
         session.flush()
 
         for item in items:
-            itemRec = Item.createOrStore(session, item, existing.id)
+            itemRec = Item.createOrStore(session, item, instance.id)
             if itemRec is not None:
                 instance.items.append(itemRec)
 

--- a/model/item.py
+++ b/model/item.py
@@ -1,4 +1,5 @@
 import os
+import re
 from sqlalchemy import (
     Column,
     ForeignKey,
@@ -26,6 +27,16 @@ from lib.outputManager import OutputManager
 from helpers.logHelpers import createLog
 
 logger = createLog('items')
+
+# SOURCES
+# gut = GUTENBERG
+# ia  = INTERNET ARCHIVE
+SOURCE_REGEX = {
+    'gut': r'gutenberg.org\/ebooks\/[0-9]+\.epub\.(?:no|)images$',
+    'ia': r'archive.org\/details\/[a-z0-9]+$'
+}
+
+EPUB_SOURCES = ['gut']
 
 class Item(Core, Base):
     """An item is an individual copy of a work in the FRBR model. In the
@@ -75,6 +86,19 @@ class Item(Core, Base):
         )
 
     @classmethod
+    def createOrStore(cls, session, item, instanceID):
+
+        url = item['link']['url']
+
+        for source, regex in SOURCE_REGEX.items():
+            if re.search(regex, url):
+                if source in EPUB_SOURCES:
+                    cls.createLocalEpub(item, instanceID)
+                    return None
+        else:
+            return cls.updateOrInsert(session, item)
+
+    @classmethod
     def createLocalEpub(cls, item, instanceID):
         """Pass new item to epub storage pipeline. Does not store item record
         at this time, but defers until epub has been processed.
@@ -84,6 +108,10 @@ class Item(Core, Base):
         id: The ID of the parent row of the item to be stored
         updated: Date the ebook was last updated at the source
         data: A raw block of the metadata associated with this item"""
+
+        url = item['link']['url']
+
+        for
 
         epubPayload = {
             'url': item['link']['url'],

--- a/model/item.py
+++ b/model/item.py
@@ -111,8 +111,6 @@ class Item(Core, Base):
 
         url = item['link']['url']
 
-        for
-
         epubPayload = {
             'url': item['link']['url'],
             'id': instanceID,

--- a/model/link.py
+++ b/model/link.py
@@ -44,7 +44,7 @@ class Link(Core, Base):
     """A generic class for describing a reference to an external resource"""
     __tablename__ = 'links'
     id = Column(Integer, primary_key=True)
-    url = Column(String(125), index=True)
+    url = Column(String(255), index=True)
     media_type = Column(String(50), index=True)
     content = Column(Unicode)
     md5 = Column(Unicode)

--- a/model/work.py
+++ b/model/work.py
@@ -61,7 +61,7 @@ class Work(Core, Base):
 
     alt_titles = relationship(
         'AltTitle',
-        secondary=WORK_ALTS
+        secondary=WORK_ALTS,
         back_populates='work'
     )
     subjects = relationship(
@@ -99,6 +99,13 @@ class Work(Core, Base):
 
     def __repr__(self):
         return '<Work(title={})>'.format(self.title)
+
+    def importSubjects(self, session, subjects):
+        for subject in subjects:
+            op, subjectRec = Subject.updateOrInsert(session, subject)
+            relExists = Work.lookupSubjectRel(session, subjectRec, self.id)
+            if relExists is None:
+                self.subjects.append(subjectRec)
 
     @classmethod
     def updateOrInsert(cls, session, workData):

--- a/model/work.py
+++ b/model/work.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from model.core import Base, Core
 from model.subject import SUBJECT_WORKS
 from model.identifiers import WORK_IDENTIFIERS, Identifier
-from model.altTitle import AltTitle
+from model.altTitle import AltTitle, WORK_ALTS
 from model.rawData import RawData
 from model.measurement import WORK_MEASUREMENTS, Measurement
 from model.link import WORK_LINKS, Link
@@ -61,6 +61,7 @@ class Work(Core, Base):
 
     alt_titles = relationship(
         'AltTitle',
+        secondary=WORK_ALTS
         back_populates='work'
     )
     subjects = relationship(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-python-lambda
+babelfish
 coverage
 flake8
+python-lambda
 pyyaml
 SQLAlchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 babelfish
 coverage
 flake8
+psycopg2-binary
 python-lambda
 pyyaml
 SQLAlchemy


### PR DESCRIPTION
This updates the database manager function to handle instance record inserts/updates. These are generally returned by the OCLC Catalog lookup function.

The data model has been extended to incorporate several new fields in the instances table, most importantly `extent` to handle physical descriptions of instances/editions, and the extension of the `alt_titles` table to relate to instances as well so that individual instances can contain multiple alternate titles. This adjustment reflects the realities of the instance records. 

The data model also more generally incorporates a `generic` identifier type that can be used when the source of an identifier is either not provided or unclear. This is used for identifiers extracted from URIs/URLs and which are unattached to a specific source or schema.

At present the function will raise a warning if it cannot merge an instance record to an existing row in the database. This is due to the structure of the data pipeline that any instance received should have already been generated from the Classify service request. If this assumption proves to be false, this will have to be handled separately from the warning.