### PR TITLE
Date field refactor

### DIFF
--- a/alembic/versions/c1ed57435412_add_new_abstract_date_class.py
+++ b/alembic/versions/c1ed57435412_add_new_abstract_date_class.py
@@ -1,0 +1,88 @@
+"""Add new abstract date class
+
+Revision ID: c1ed57435412
+Revises: f0645598beea
+Create Date: 2019-01-10 11:37:45.366597
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import DATERANGE
+
+
+# revision identifiers, used by Alembic.
+revision = 'c1ed57435412'
+down_revision = 'f0645598beea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('display_date', sa.Unicode, index=True),
+        sa.Column('date_range', DATERANGER, index=True),
+        sa.Column('date_type', sa.Unicode, index=True),
+        sa.Column('date_created', sa.DateTime, default=datetime.now()),
+        sa.Column('date_modified', sa.DateTime, default=datetime.now(), onupdate=datetime.now())
+    )
+    op.create_table(
+        'work_dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('work_id', sa.Integer, sa.ForeignKey('works.id')),
+        sa.Column('date_id', sa.Integer, sa.ForeignKey('dates.id'))
+    )
+    op.create_table(
+        'instance_dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('instance_id', sa.Integer, sa.ForeignKey('instances.id')),
+        sa.Column('date_id', sa.Integer, sa.ForeignKey('dates.id'))
+    )
+    op.create_table(
+        'item_dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('item_id', sa.Integer, sa.ForeignKey('item.id')),
+        sa.Column('date_id', sa.Integer, sa.ForeignKey('dates.id'))
+    )
+    op.create_table(
+        'agent_dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('agent_id', sa.Integer, sa.ForeignKey('agents.id')),
+        sa.Column('date_id', sa.Integer, sa.ForeignKey('dates.id'))
+    )
+
+    op.drop_column('agents', 'birth_date')
+    op.drop_column('agents', 'death_date')
+
+    op.drop_column('instances', 'pub_date')
+
+    op.drop_column('works', 'issued')
+    op.drop_column('works', 'published')
+
+
+def downgrade():
+    op.drop_table('agent_dates')
+    op.drop_table('item_dates')
+    op.drop_table('instance_dates')
+    op.drop_table('work_dates')
+    op.drop_table('dates')
+
+    op.add_column('agents',
+        sa.Column('birth_date', sa.Date)
+    )
+    op.add_column('agents',
+        sa.Column('death_date', sa.Date)
+    )
+
+    op.add_column('instances',
+        sa.Column('pub_date', sa.Date)
+    )
+
+    op.add_column('works',
+        sa.Column('issued', sa.Date)
+    )
+
+    op.add_column('works',
+        sa.Column('published', sa.Date)
+    )

--- a/model/agent.py
+++ b/model/agent.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from model.core import Base, Core
 from model.link import AGENT_LINKS, Link
-from model.date import AGENT_DATES
+from model.date import AGENT_DATES, Date
 
 from helpers.logHelpers import createLog
 
@@ -137,13 +137,13 @@ class Agent(Core, Base):
             for alias in list(map(lambda x: Alias(alias=x), aliases)):
                 agent.aliases.append(alias)
 
-        if link is not None:
+        for link in link:
             newLink = Link(**link)
             agent.links.append(newLink)
 
         for date in dates:
             newDate = Date.insert(date)
-            work.dates.append(newDate)
+            agent.dates.append(newDate)
 
         return agent
 

--- a/model/agent.py
+++ b/model/agent.py
@@ -52,7 +52,7 @@ class Agent(Core, Base):
     dates = relationship(
         'Date',
         secondary=AGENT_DATES,
-        back_populates='agent'
+        back_populates='agents'
     )
 
     def __repr__(self):

--- a/model/date.py
+++ b/model/date.py
@@ -1,0 +1,154 @@
+import re
+from dateutil.parser import parse
+from datetime import date
+from calendar import monthrange
+from psycopg2.extras import DateRange
+from sqlalchemy import (
+    Table,
+    Column,
+    Unicode,
+    Integer,
+    ForeignKey
+)
+from sqlalchemy.dialects.postgresql import DATERANGE
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import text
+from sqlalchemy.orm.exc import NoResultFound
+
+from model.core import Base, Core
+
+from helpers.errorHelpers import DBError
+from helpers.logHelpers import createLog
+
+logger = createLog('dateModel')
+
+WORK_DATES = Table(
+    'work_dates',
+    Base.metadata,
+    Column('work_id', Integer, ForeignKey('works.id')),
+    Column('date_id', Integer, ForeignKey('dates.id'))
+)
+
+INSTANCE_DATES = Table(
+    'instance_dates',
+    Base.metadata,
+    Column('instance_id', Integer, ForeignKey('instances.id')),
+    Column('date_id', Integer, ForeignKey('dates.id'))
+)
+
+ITEM_DATES = Table(
+    'item_dates',
+    Base.metadata,
+    Column('item_id', Integer, ForeignKey('items.id')),
+    Column('date_id', Integer, ForeignKey('dates.id'))
+)
+
+AGENT_DATES = Table(
+    'agent_dates',
+    Base.metadata,
+    Column('agent_id', Integer, ForeignKey('agents.id')),
+    Column('date_id', Integer, ForeignKey('dates.id'))
+)
+
+
+class Date(Core, Base):
+    """An abstract class that represents a date value, associated with any
+    entity or record in the SFR data model. This class contains a set of fields
+    that store both human-readable and parsable date range values. While an
+    ISO-8601 value is recommended for the human-readable component this
+    is not required
+    @value display_date
+    @value date_range
+    @value date_type"""
+
+    __tablename__ = 'dates'
+    id = Column(Integer, primary_key=True)
+    display_date = Column(Unicode, index=True)
+    date_range = Column(DATERANGE, index=True)
+    date_type = Column(Unicode, index=True)
+
+    work = relationship(
+        'Work',
+        secondary=WORK_DATES,
+        back_populates='dates'
+    )
+    instance = relationship(
+        'Instance',
+        secondary=INSTANCE_DATES,
+        back_populates='dates'
+    )
+    item = relationship(
+        'Item',
+        secondary=ITEM_DATES,
+        back_populates='dates'
+    )
+    agent = relationship(
+        'Agent',
+        secondary=AGENT_DATES,
+        back_populates='dates'
+    )
+
+    def __repr__(self):
+        return '<Date(date={})>'.format(self.display_date)
+
+    @classmethod
+    def updateOrInsert(cls, session, date, model, recordID):
+        """Query the database for a date on the current record. If found,
+        update the existing date, if not, insert new row"""
+        existing = Date.lookupDate(session, date, model, recordID)
+        if existing is not None:
+            Date.update(existing, link)
+            return None
+
+        return Date.insert(date)
+
+    @classmethod
+    def update(cls, existing, date):
+        """Update fields on existing date"""
+        for field, value in date.items():
+            if(
+                value is not None
+                and value.strip() != ''
+                and field != 'date_range'
+            ):
+                setattr(existing, field, value)
+
+        existing.date_range = Date.parseDate(date['date_range'])
+
+    @classmethod
+    def insert(cls, dateData):
+        """Insert a new date row"""
+        date = Date()
+        for field, value in dateData.items():
+            if field != 'date_range':
+                setattr(date, field, value)
+            else:
+                setattr(date, field, Date.parseDate(value))
+
+        return date
+
+    @classmethod
+    def lookupDate(cls, session, link, model, recordID):
+        """Query database for link related to current record. Return link
+        if found, otherwise return None"""
+        return session.query(cls)\
+            .join(model.__tablename__)\
+            .filter(model.id == recordID)\
+            .filter(cls.date_type == date['date_type'])\
+            .one_or_none()
+
+    @staticmethod
+    def parseDate(date):
+        if type(date) is list:
+            return DateRange(parse(date[0]), parse(date[1]))
+        elif re.match(r'^[0-9]{4}$', date):
+            year = parse(date).year
+            return DateRange(date(year, 1, 1), date(year, 12, 31))
+        elif re.match(r'^[0-9]{4}-[0-9]{2}$', date):
+            dateObj = parse(date)
+            year = dateObj.year
+            month = dateObj.month
+            lastDay = monthrange(year, month)[1]  # Accounts for leap years
+            return DateRange(date(year, month, 1), date(year, month, lastDay))
+        else:
+            return DateRange(parse(date), None)

--- a/model/instance.py
+++ b/model/instance.py
@@ -71,6 +71,7 @@ class Instance(Core, Base):
     dates = relationship(
         'Date',
         secondary=INSTANCE_DATES,
+        back_populates='instances'
     )
     alt_titles = relationship(
         'AltTitle',
@@ -152,9 +153,6 @@ class Instance(Core, Base):
         if instance['language'] is not None and len(instance['language']) != 2:
             lang = babelfish.Language(instance['language'])
             instance['language'] = lang.alpha2
-
-        if instance['pub_date'] is not None:
-            instance['pub_date'] = datetime.strptime(instance['pub_date'], '%Y')
 
         for field, value in instance.items():
             if(value is not None):

--- a/model/item.py
+++ b/model/item.py
@@ -82,7 +82,7 @@ class Item(Core, Base):
     dates = relationship(
         'Date',
         secondary=ITEM_DATES,
-        back_populates='item'
+        back_populates='items'
     )
 
     def __repr__(self):

--- a/model/work.py
+++ b/model/work.py
@@ -94,7 +94,7 @@ class Work(Core, Base):
     dates = relationship(
         'Date',
         secondary=WORK_DATES,
-        back_populates='work'
+        back_populates='works'
     )
     import_json = relationship(
         'RawData',
@@ -316,7 +316,6 @@ class Work(Core, Base):
         for date in dates:
             newDate = Date.insert(date)
             work.dates.append(newDate)
-
         return work
 
     @classmethod

--- a/model/work.py
+++ b/model/work.py
@@ -20,6 +20,7 @@ from model.altTitle import AltTitle
 from model.rawData import RawData
 from model.measurement import WORK_MEASUREMENTS, Measurement
 from model.link import WORK_LINKS, Link
+from model.date import WORK_DATES, Date
 from model.instance import Instance
 from model.agent import Agent
 from model.subject import Subject
@@ -47,8 +48,6 @@ class Work(Core, Base):
     sort_title = Column(Unicode, index=True)
     sub_title = Column(Unicode, index=True)
     language = Column(String(2), index=True)
-    issued = Column(Date)
-    published = Column(Date)
     license = Column(String(50))
     rights_statement = Column(Unicode)
     medium = Column(Unicode)
@@ -91,6 +90,11 @@ class Work(Core, Base):
         secondary=WORK_LINKS,
         back_populates='works'
     )
+    dates = relationship(
+        'Date',
+        secondary=WORK_DATES,
+        back_populates='work'
+    )
     import_json = relationship(
         'RawData',
         back_populates='work'
@@ -114,6 +118,7 @@ class Work(Core, Base):
         identifiers = workData.pop('identifiers', None)
         measurements = workData.pop('measurements', None)
         links = workData.pop('links', None)
+        dates = workData.pop('dates', None)
 
         existing = cls.lookupWork(session, identifiers, primaryIdentifier)
         if existing is not None:
@@ -128,6 +133,7 @@ class Work(Core, Base):
                 subjects=subjects,
                 measurements=measurements,
                 links=links,
+                dates=dates,
                 json=storeJson
             )
             return 'update', updated
@@ -143,6 +149,7 @@ class Work(Core, Base):
             subjects=subjects,
             measurements=measurements,
             links=links,
+            dates=dates,
             json=storeJson
         )
 
@@ -161,6 +168,7 @@ class Work(Core, Base):
         measurements = kwargs.get('measurements', [])
         links = kwargs.get('links', [])
         storeJson = kwargs.get('json')
+        dates = kwargs.get('dates', [])
 
         jsonRec = RawData(data=storeJson)
         existing.import_json.append(jsonRec)
@@ -228,6 +236,11 @@ class Work(Core, Base):
             if updateLink is not None:
                 existing.links.append(updateLink)
 
+        for date in dates:
+            updateDate = Date.updateOrInsert(session, date, Work, existing.id)
+            if updateDate is not None:
+                existing.dates.append(updateDate)
+
         return existing
 
     @classmethod
@@ -255,6 +268,7 @@ class Work(Core, Base):
         measurements = kwargs.get('measurements', [])
         links = kwargs.get('links', [])
         storeJson = kwargs.get('json')
+        dates = kwargs.get('dates', [])
 
         jsonRec = RawData(data=storeJson)
         work.import_json.append(jsonRec)
@@ -290,6 +304,10 @@ class Work(Core, Base):
         for link in links:
             newLink = Link(**link)
             work.links.append(newLink)
+
+        for date in dates:
+            newDate = Date.insert(date)
+            work.dates.append(newDate)
 
         return work
 

--- a/service.py
+++ b/service.py
@@ -1,7 +1,7 @@
 import json
 import base64
 
-from helpers.errorHelpers import NoRecordsReceived
+from helpers.errorHelpers import NoRecordsReceived, DBError
 from helpers.logHelpers import createLog
 from lib.dbManager import dbGenerateConnection, importRecord, createSession
 

--- a/service.py
+++ b/service.py
@@ -1,5 +1,6 @@
 import json
 import base64
+import traceback
 
 from helpers.errorHelpers import NoRecordsReceived, DataError, DBError
 from helpers.logHelpers import createLog
@@ -95,6 +96,7 @@ def parseRecord(encodedRec):
         session.rollback()
         logger.error('Failed to store record')
         logger.debug(err)
+        logger.debug(traceback.format_exc())
         raise DBError('unknown', 'Unable to parse/ingest record, see logs for error')
     finally:
         logger.debug('Closing Session')

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch
+from collections import namedtuple
+
+from model.date import Date
+
+TestDate = namedtuple('TestDate', ['id', 'display_date', 'date_range', 'date_type'])
+
+class TestDates(unittest.TestCase):
+
+    @patch('model.date.Date.lookupDate', return_value=None)
+    @patch('model.date.Date.insert', return_value=True)
+    def test_check_new(self, mock_insert, mock_lookup):
+        res = Date.updateOrInsert('session', {'display_date': 'date'}, 'Date', 1)
+        mock_lookup.expect_to_be_called()
+        self.assertTrue(res)
+
+    td = TestDate(
+        id=1,
+        display_date='test',
+        date_range='[1,2)',
+        date_type='tester'
+    )
+    @patch('model.date.Date.lookupDate', return_value=td)
+    @patch('model.date.Date.update')
+    def test_check_new(self, mock_update, mock_lookup):
+        res = Date.updateOrInsert('session', {'display_date': 'date'}, 'Date', 1)
+        mock_lookup.expect_to_be_called()
+        mock_update.expect_to_be_called()
+        self.assertEqual(res, None)
+
+
+    @patch('model.date.Date.parseDate', return_value='[3,4)')
+    def test_update_date(self, mock_parse):
+        newTest = Date(
+            id=1,
+            display_date='test',
+            date_range='[1,2)',
+            date_type='tester'
+        )
+        newDate = {
+            'display_date': 'new',
+            'date_range': '[3,4)'
+        }
+        Date.update(newTest, newDate)
+        self.assertEqual(newTest.display_date, 'new')
+        self.assertEqual(newTest.date_range, '[3,4)')
+
+    @patch('model.date.Date.parseDate', return_value='[3,4)')
+    def test_insert_date(self, mock_parse):
+        newDate = {
+            'display_date': 'new',
+            'date_range': '[3,4)',
+            'date_type': 'tester'
+        }
+        res = Date.insert(newDate)
+        self.assertEqual(res.display_date, 'new')
+        self.assertEqual(res.date_range, '[3,4)')
+        self.assertEqual(res.date_type, 'tester')
+
+    def test_parse_single_date(self):
+        res = Date.parseDate('2018-01-10')
+        self.assertEqual(res, '[2018-01-10,)')
+
+    def test_parse_date_list(self):
+        res = Date.parseDate(['2018-01-10', '2018-01-11'])
+        self.assertEqual(res, '[2018-01-10, 2018-01-11)')
+
+    def test_parse_year(self):
+        res = Date.parseDate('2018')
+        self.assertEqual(res, '[2018-01-01, 2018-12-31)')
+
+    def test_parse_month(self):
+        res = Date.parseDate('2018-02')
+        self.assertEqual(res, '[2018-02-01, 2018-02-28)')
+
+    def test_parse_bad_date(self):
+        res = Date.parseDate('Modnay, Dec 01, 87')
+        self.assertEqual(res, None)


### PR DESCRIPTION
This adds an abstract date class to the SFR database model, which allows for easier parsing of dates as well for better support of date ranges and display dates. At present dates can be associated with works, instances, items and agents

The date class includes three fields:
- date_type: The specific type of date as pertains to the relevant record. Abstracting this removes restrictions on what types of dates can be associated with records without adding a db migration.
- date_range: This is postgreSQL DateRange field, which enables the most accurate searching/filtering for a wide range of dates (for example when we have only a year for publication date, but a specific day for when a resource was created)
- display_date: This is a human readable format and can be set to anything (it is a Unicode field). Separating this from the value used for sorting/searching means that we can store dates in idiosyncratic format if desired for display, as long as a standardized format is provided as well