### PR TITLE
Rights class refactor

### DIFF
--- a/alembic/versions/59c8cd1935d7_add_new_abstract_rights_class.py
+++ b/alembic/versions/59c8cd1935d7_add_new_abstract_rights_class.py
@@ -1,0 +1,93 @@
+"""Add new abstract rights class
+
+Revision ID: 59c8cd1935d7
+Revises: d7f930355ed1
+Create Date: 2019-02-01 16:29:34.441348
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime
+
+
+# revision identifiers, used by Alembic.
+revision = '59c8cd1935d7'
+down_revision = 'd7f930355ed1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'rights',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('source', sa.Unicode, index=True),
+        sa.Column('rights_statement', sa.Unicode, index=True),
+        sa.Column('rights_reason', sa.Unicode, index=True),
+        sa.Column('date_created', sa.DateTime, default=datetime.now()),
+        sa.Column(
+            'date_modified',
+            sa.DateTime,
+            default=datetime.now(),
+            onupdate=datetime.now()
+        )
+    )
+    op.create_table(
+        'work_rights',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('work_id', sa.Integer, sa.ForeignKey('works.id')),
+        sa.Column('rights_id', sa.Integer, sa.ForeignKey('rights.id'))
+    )
+    op.create_table(
+        'instance_rights',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('instance_id', sa.Integer, sa.ForeignKey('instances.id')),
+        sa.Column('rights_id', sa.Integer, sa.ForeignKey('rights.id'))
+    )
+    op.create_table(
+        'item_rights',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('item_id', sa.Integer, sa.ForeignKey('items.id')),
+        sa.Column('rights_id', sa.Integer, sa.ForeignKey('rights.id'))
+    )
+    op.create_table(
+        'rights_dates',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('rights_id', sa.Integer, sa.ForeignKey('rights.id')),
+        sa.Column('date_id', sa.Integer, sa.ForeignKey('dates.id'))
+    )
+
+    op.drop_column('works', 'license')
+    op.drop_column('works', 'rights_statement')
+
+    op.drop_column('instances', 'license')
+    op.drop_column('instances', 'rights_statement')
+
+    op.drop_column('items', 'rights_uri')
+
+def downgrade():
+    op.drop_table('rights_dates')
+    op.drop_table('item_rights')
+    op.drop_table('instance_rights')
+    op.drop_table('work_rights')
+    op.drop_table('rights')
+
+    op.add_column('works',
+        sa.Column('license', sa.Unicode)
+    )
+    op.add_column('works',
+        sa.Column('rights_statement', sa.Unicode)
+    )
+
+    op.add_column('instance',
+        sa.Column('license', sa.Unicode)
+    )
+    op.add_column('instance',
+        sa.Column('rights_statement', sa.Unicode)
+    )
+
+    op.add_column('item',
+        sa.Column('rights_uri', sa.Unicode)
+    )
+
+

--- a/alembic/versions/844b6f4ed646_add_license_field_to_rights.py
+++ b/alembic/versions/844b6f4ed646_add_license_field_to_rights.py
@@ -1,0 +1,26 @@
+"""Add license field to rights
+
+Revision ID: 844b6f4ed646
+Revises: 59c8cd1935d7
+Create Date: 2019-02-04 14:52:40.610752
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '844b6f4ed646'
+down_revision = '59c8cd1935d7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+     op.add_column('rights',
+        sa.Column('license', sa.Unicode, nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('rights', 'license')

--- a/alembic/versions/d7f930355ed1_merge_date_class_and_instance_updates.py
+++ b/alembic/versions/d7f930355ed1_merge_date_class_and_instance_updates.py
@@ -1,0 +1,24 @@
+"""Merge date class and instance updates
+
+Revision ID: d7f930355ed1
+Revises: 594957f8b6cc, c1ed57435412
+Create Date: 2019-02-01 16:29:26.925335
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7f930355ed1'
+down_revision = ('594957f8b6cc', 'c1ed57435412')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -118,7 +118,7 @@ def importRecord(session, record):
             session.add(dbItem)
             session.flush()
         
-        dbItem.instsance.work.date_modified = datetime.now()
+        dbItem.instance.work.date_modified = datetime.now()
         OutputManager.putQueue({
             'type': 'work',
             'identifier': dbItem.instance.work.uuid.hex

--- a/model/agent.py
+++ b/model/agent.py
@@ -49,11 +49,6 @@ class Agent(Core, Base):
         secondary=AGENT_LINKS,
         back_populates='agents'
     )
-    dates = relationship(
-        'DateField',
-        secondary=AGENT_DATES,
-        back_populates='agents'
-    )
 
     def __repr__(self):
         return '<Agent(name={}, sort_name={}, lcnaf={}, viaf={})>'.format(

--- a/model/date.py
+++ b/model/date.py
@@ -50,6 +50,12 @@ AGENT_DATES = Table(
     Column('date_id', Integer, ForeignKey('dates.id'))
 )
 
+RIGHTS_DATES = Table(
+    'rights_dates',
+    Base.metadata,
+    Column('rights_id', Integer, ForeignKey('rights.id')),
+    Column('date_id', Integer, ForeginKeu('dates.id'))
+)
 
 class DateField(Core, Base):
     """An abstract class that represents a date value, associated with any
@@ -85,6 +91,11 @@ class DateField(Core, Base):
     agents = relationship(
         'Agent',
         secondary=AGENT_DATES,
+        back_populates='dates'
+    )
+    rights = relationship(
+        'Rights',
+        secondary=RIGHTS_DATES,
         back_populates='dates'
     )
 

--- a/model/date.py
+++ b/model/date.py
@@ -54,7 +54,7 @@ RIGHTS_DATES = Table(
     'rights_dates',
     Base.metadata,
     Column('rights_id', Integer, ForeignKey('rights.id')),
-    Column('date_id', Integer, ForeginKeu('dates.id'))
+    Column('date_id', Integer, ForeignKey('dates.id'))
 )
 
 class DateField(Core, Base):
@@ -76,50 +76,50 @@ class DateField(Core, Base):
     works = relationship(
         'Work',
         secondary=WORK_DATES,
-        back_populates='dates'
+        backref='dates'
     )
     instances = relationship(
         'Instance',
         secondary=INSTANCE_DATES,
-        back_populates='dates'
+        backref='dates'
     )
     items = relationship(
         'Item',
         secondary=ITEM_DATES,
-        back_populates='dates'
+        backref='dates'
     )
     agents = relationship(
         'Agent',
         secondary=AGENT_DATES,
-        back_populates='dates'
+        backref='dates'
     )
     rights = relationship(
         'Rights',
         secondary=RIGHTS_DATES,
-        back_populates='dates'
+        backref='dates'
     )
 
     def __repr__(self):
         return '<Date(date={})>'.format(self.display_date)
 
     @classmethod
-    def updateOrInsert(cls, session, date, model, recordID):
-        logger.debug('Inserting or updating date {}'.format(date['display_date']))
+    def updateOrInsert(cls, session, dateInst, model, recordID):
+        logger.debug('Inserting or updating date {}'.format(dateInst['display_date']))
         """Query the database for a date on the current record. If found,
         update the existing date, if not, insert new row"""
-        existing = DateField.lookupDate(session, date, model, recordID)
+        existing = DateField.lookupDate(session, dateInst, model, recordID)
         if existing is not None:
             logger.info('Updating existing date record {}'.format(existing.id))
-            DateField.update(existing, date)
+            DateField.update(existing, dateInst)
             return None
 
         logger.info('Inserting new date object')
-        return DateField.insert(date)
+        return DateField.insert(dateInst)
 
     @classmethod
-    def update(cls, existing, date):
+    def update(cls, existing, dateInst):
         """Update fields on existing date"""
-        for field, value in date.items():
+        for field, value in dateInst.items():
             if(
                 value is not None
                 and value.strip() != ''
@@ -127,28 +127,28 @@ class DateField(Core, Base):
             ):
                 setattr(existing, field, value)
 
-        existing.date_range = DateField.parseDate(date['date_range'])
+        existing.date_range = DateField.parseDate(dateInst['date_range'])
 
     @classmethod
     def insert(cls, dateData):
         """Insert a new date row"""
-        date = DateField()
+        dateInst = cls()
         for field, value in dateData.items():
             if field != 'date_range':
-                setattr(date, field, value)
+                setattr(dateInst, field, value)
             else:
-                setattr(date, field, DateField.parseDate(value))
+                setattr(dateInst, field, DateField.parseDate(value))
 
-        return date
+        return dateInst
 
     @classmethod
-    def lookupDate(cls, session, date, model, recordID):
+    def lookupDate(cls, session, dateInst, model, recordID):
         """Query database for link related to current record. Return link
         if found, otherwise return None"""
         return session.query(cls)\
             .join(model.__tablename__)\
             .filter(model.id == recordID)\
-            .filter(cls.date_type == date['date_type'])\
+            .filter(cls.date_type == dateInst['date_type'])\
             .one_or_none()
 
     @staticmethod

--- a/model/instance.py
+++ b/model/instance.py
@@ -99,7 +99,7 @@ class Instance(Core, Base):
         dates = instance.pop('dates', [])
         links = instance.pop('links', [])
         alt_titles = instance.pop('alt_titles', None)
-        rights = instance.pop('rights', None)
+        rights = instance.pop('rights', [])
 
         # Get fields targeted for works
         series = instance.pop('series', None)

--- a/model/instance.py
+++ b/model/instance.py
@@ -22,6 +22,7 @@ from model.date import INSTANCE_DATES, DateField
 from model.item import Item
 from model.agent import Agent
 from model.altTitle import INSTANCE_ALTS, AltTitle
+from model.rights import Rights, INSTANCE_RIGHTS
 
 from helpers.logHelpers import createLog
 
@@ -73,11 +74,7 @@ class Instance(Core, Base):
         secondary=INSTANCE_LINKS,
         back_populates='instances'
     )
-    dates = relationship(
-        'DateField',
-        secondary=INSTANCE_DATES,
-        back_populates='instances'
-    )
+    
     alt_titles = relationship(
         'AltTitle',
         secondary=INSTANCE_ALTS,
@@ -102,6 +99,7 @@ class Instance(Core, Base):
         dates = instance.pop('dates', [])
         links = instance.pop('links', [])
         alt_titles = instance.pop('alt_titles', None)
+        rights = instance.pop('rights', None)
 
         # Get fields targeted for works
         series = instance.pop('series', None)
@@ -130,7 +128,8 @@ class Instance(Core, Base):
                 measurements=measurements,
                 dates=dates,
                 links=links,
-                alt_titles=alt_titles
+                alt_titles=alt_titles,
+                rights=rights
             )
             return existing, 'updated'
 
@@ -143,7 +142,8 @@ class Instance(Core, Base):
             measurements=measurements,
             dates=dates,
             links=links,
-            alt_titles=alt_titles
+            alt_titles=alt_titles,
+            rights=rights
         )
         return newInstance, 'inserted'
 
@@ -157,6 +157,7 @@ class Instance(Core, Base):
         altTitles = kwargs.get('alt_titles', [])
         links = kwargs.get('links', [])
         dates = kwargs.get('dates', [])
+        rights = kwargs.get('rights', [])
 
         if instance['language'] is not None and len(instance['language']) != 2:
             langs = re.split(r'\W+', instance['language'])
@@ -218,6 +219,16 @@ class Instance(Core, Base):
             updateLink = Link.updateOrInsert(session, link, Instance, existing.id)
             if updateLink is not None:
                 existing.links.append(updateLink)
+        
+        for rightsStmt in rights:
+            updateRights = Rights.updateOrInsert(
+                session,
+                rightsStmt,
+                Instance,
+                existing.id
+            )
+            if updateRights is not None:
+                existing.rights.append(updateRights)
 
         return existing
 
@@ -243,6 +254,7 @@ class Instance(Core, Base):
         altTitles = kwargs.get('alt_titles', [])
         links = kwargs.get('links', [])
         dates = kwargs.get('dates', [])
+        rights = kwargs.get('rights', [])
 
         if agents is not None:
             for agent in agents:
@@ -273,6 +285,10 @@ class Instance(Core, Base):
         for date in dates:
             newDate = DateField.insert(date)
             instance.dates.append(newDate)
+        
+        for rightsStmt in rights:
+            newRights = Rights.insert(rightsStmt)
+            instance.rights.append(newRights)
 
         # We need to get the ID of the instance to allow for asynchronously
         # storing the ePub file, so instance is added and flushed here

--- a/model/instance.py
+++ b/model/instance.py
@@ -43,9 +43,7 @@ class Instance(Core, Base):
     copyright_date = Column(Date, index=True)
     language = Column(String(2), index=True)
     extent = Column(Unicode)
-    license = Column(String(255))
-    rights_statement = Column(Unicode)
-
+    
     work_id = Column(Integer, ForeignKey('works.id'))
 
     work = relationship(

--- a/model/item.py
+++ b/model/item.py
@@ -49,8 +49,7 @@ class Item(Core, Base):
     content_type = Column(Unicode, index=True)
     modified = Column(DateTime, index=True)
     drm = Column(Unicode, index=True)
-    rights_uri = Column(Unicode, index=True)
-
+    
     instance_id = Column(Integer, ForeignKey('instances.id'))
 
     instance = relationship(

--- a/model/link.py
+++ b/model/link.py
@@ -49,7 +49,6 @@ class Link(Core, Base):
     content = Column(Unicode)
     md5 = Column(Unicode)
     rel_type = Column(String(50), index=True)
-    rights_uri = Column(Unicode, index=True)
     thumbnail = Column(Integer, ForeignKey('links.id'))
 
     works = relationship(

--- a/model/rights.py
+++ b/model/rights.py
@@ -1,0 +1,134 @@
+from sqlalchemy import (
+    Table,
+    Column,
+    Unicode,
+    Integer,
+    ForeignKey
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import text
+from sqlalchemy.orm.exc import NoResultFound
+
+from model.core import Base, Core
+
+from helpers.errorHelpers import DBError
+from helpers.logHelpers import createLog
+
+logger = createLog('rightsModel')
+
+WORK_RIGHTS = Table(
+    'work_rights',
+    Base.metadata,
+    Column('work_id', Integer, ForeignKey('works.id')),
+    Column('rights_id', Integer, ForeignKey('rights.id'))
+)
+
+INSTANCE_RIGHTS = Table(
+    'instance_rights',
+    Base.metadata,
+    Column('instance_id', Integer, ForeignKey('instances.id')),
+    Column('rights_id', Integer, ForeignKey('rights.id'))
+)
+
+ITEM_RIGHTS = Table(
+    'item_rights',
+    Base.metadata,
+    Column('item_id', Integer, ForeignKey('items.id')),
+    Column('rights_id', Integer, ForeignKey('rights.id'))
+)
+
+
+class Rights(Core, Base):
+    """An abstract class that represents a rights assessment. This can apply
+    to any level in the SFR metadata model, and should include a resolvable
+    URI and a human readable component, though the URI is not strictly 
+    required. Additionally a rationale for the assessment can be provided
+
+    @value source -- institution/individual that has made the assessment
+    @value license -- string (preferably URI) that defines the assigned rights
+    @value rights_statement -- human readable version of the rights assessment
+    @value rights_reason -- a justification for the rights statement
+    @value dates -- list of dates associated with the rights assessment
+    """
+
+    __tablename__ = 'rights'
+    id = Column(Integer, primary_key=True)
+    license = Column(Unicode, index=True)
+    rights_statement = Column(Unicode, index=True)
+    rights_reason = Column(Unicode, index=True)
+
+    works = relationship(
+        'Work',
+        secondary=WORK_DATES,
+        back_populates='dates'
+    )
+    instances = relationship(
+        'Instance',
+        secondary=INSTANCE_DATES,
+        back_populates='dates'
+    )
+    items = relationship(
+        'Item',
+        secondary=ITEM_DATES,
+        back_populates='dates'
+    )
+    dates = relationship(
+        'Date',
+        secondary=RIGHTS_DATES,
+        back_populates='dates'
+    )
+
+    def __repr__(self):
+        return '<Rights(source={}, license={})>'.format(
+            self.source,
+            self.license
+        )
+
+    @classmethod
+    def updateOrInsert(cls, session, rights, model, recordID):
+        logger.debug('Inserting or updating rights {} on record {}'.format(
+            rights['license'],
+            recordID
+        ))
+        """Query the database for rights from the provided source on the
+        current record. If found, update the existing date, if not, insert new
+        row"""
+        existing = Rights.lookupRights(session, rights, model, recordID)
+        if existing is not None:
+            logger.info('Updating existing rights record {}'.format(
+                existing.id
+            ))
+            Rights.update(existing, date)
+            return None
+
+        logger.info('Inserting new date object')
+        return Rights.insert(date)
+
+    @classmethod
+    def update(cls, existing, rights):
+        """Update fields on existing rights assessment"""
+        for field, value in rights.items():
+            if(
+                value is not None
+                and value.strip() != ''
+            ):
+                setattr(existing, field, value)
+
+    @classmethod
+    def insert(cls, rightsData):
+        """Insert a new rights row"""
+        rights = Rights()
+        for field, value in rightsData.items():
+            setattr(rights, field, value)
+
+        return rights
+
+    @classmethod
+    def lookupRights(cls, session, rights, model, recordID):
+        """Query database for link related to current record. Return link
+        if found, otherwise return None"""
+        return session.query(cls)\
+            .join(model.__tablename__)\
+            .filter(model.id == recordID)\
+            .filter(cls.source == date['source'])\
+            .one_or_none()

--- a/model/rights.py
+++ b/model/rights.py
@@ -54,7 +54,7 @@ class Rights(Core, Base):
 
     __tablename__ = 'rights'
     id = Column(Integer, primary_key=True)
-    source = Column(Unicoe, index=True)
+    source = Column(Unicode, index=True)
     license = Column(Unicode, index=True)
     rights_statement = Column(Unicode, index=True)
     rights_reason = Column(Unicode, index=True)

--- a/model/rights.py
+++ b/model/rights.py
@@ -54,6 +54,7 @@ class Rights(Core, Base):
 
     __tablename__ = 'rights'
     id = Column(Integer, primary_key=True)
+    source = Column(Unicoe, index=True)
     license = Column(Unicode, index=True)
     rights_statement = Column(Unicode, index=True)
     rights_reason = Column(Unicode, index=True)

--- a/model/work.py
+++ b/model/work.py
@@ -123,7 +123,7 @@ class Work(Core, Base):
         measurements = workData.pop('measurements', None)
         links = workData.pop('links', None)
         dates = workData.pop('dates', None)
-        rights = workData.pop('rights', None)
+        rights = workData.pop('rights', [])
 
         existing = cls.lookupWork(session, identifiers, primaryIdentifier)
         if existing is not None:
@@ -272,7 +272,7 @@ class Work(Core, Base):
 
         # TODO Remove prepositions, etc from the start of the sort title
         workData['sort_title'] = workData.get('sort_title', workData['title'])
-        print(workData)
+        
         work = cls(**workData)
         #
         # === IMPORTANT ===

--- a/model/work.py
+++ b/model/work.py
@@ -291,6 +291,7 @@ class Work(Core, Base):
         links = kwargs.get('links', [])
         storeJson = kwargs.get('json')
         dates = kwargs.get('dates', [])
+        rights = kwargs.get('rights', [])
 
         jsonRec = RawData(data=storeJson)
         work.import_json.append(jsonRec)

--- a/model/work.py
+++ b/model/work.py
@@ -49,8 +49,6 @@ class Work(Core, Base):
     sort_title = Column(Unicode, index=True)
     sub_title = Column(Unicode, index=True)
     language = Column(String(2), index=True)
-    license = Column(String(50))
-    rights_statement = Column(Unicode)
     medium = Column(Unicode)
     series = Column(Unicode)
     series_position = Column(Unicode)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -6,6 +6,7 @@ from model.date import DateField
 
 TestDate = namedtuple('TestDate', ['id', 'display_date', 'date_range', 'date_type'])
 
+
 class TestDates(unittest.TestCase):
 
     @patch('model.date.DateField.lookupDate', return_value=None)
@@ -23,7 +24,7 @@ class TestDates(unittest.TestCase):
     )
     @patch('model.date.DateField.lookupDate', return_value=td)
     @patch('model.date.DateField.update')
-    def test_check_new(self, mock_update, mock_lookup):
+    def test_check_existing(self, mock_update, mock_lookup):
         res = DateField.updateOrInsert('session', {'display_date': 'date'}, 'Date', 1)
         mock_lookup.expect_to_be_called()
         mock_update.expect_to_be_called()

--- a/tests/test_rights.py
+++ b/tests/test_rights.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import patch
+from collections import namedtuple
+
+from model.rights import Rights
+
+RightsTup = namedtuple('TestRights',
+    ['id', 'source', 'license', 'rights_statement', 'rights_reason', 'dates']
+)
+
+
+class TestRights(unittest.TestCase):
+
+    @patch('model.rights.Rights.lookupRights', return_value=None)
+    @patch('model.rights.Rights.insert', return_value=True)
+    def test_check_new(self, mock_insert, mock_lookup):
+        res = Rights.updateOrInsert(
+            'session',
+            {'license': 'rghts'},
+            'Rights',
+            1
+        )
+        mock_lookup.expect_to_be_called()
+        self.assertTrue(res)
+
+    tr = RightsTup(
+        id=1,
+        source='test',
+        license='rights_uri',
+        rights_statement='Sample Statement',
+        rights_reason='Sample Reason',
+        dates=[]
+    )
+    @patch('model.rights.Rights.lookupRights', return_value=tr)
+    @patch('model.rights.Rights.update')
+    def test_check_existing(self, mock_update, mock_lookup):
+        res = Rights.updateOrInsert(
+            'session',
+            {'license': 'new_uri'},
+            'Date',
+            1
+        )
+        mock_lookup.expect_to_be_called()
+        mock_update.expect_to_be_called()
+        self.assertEqual(res, None)
+
+
+    def test_update_rights(self):
+        newTest = Rights.insert({
+            'id': 1,
+            'source': 'test',
+            'license': 'rights_uri',
+            'rights_statement': 'Sample Statement',
+            'rights_reason': 'Sample Reason',
+        }, dates=[])
+        newRights = {
+            'source': 'other',
+            'license': 'new_uri'
+        }
+        Rights.update('session', newTest, newRights)
+        self.assertEqual(newTest.source, 'other')
+        self.assertEqual(newTest.license, 'new_uri')
+
+    def test_insert_rights(self):
+        newRights = {
+            'source': 'other',
+            'license': 'new_uri',
+            'rights_statement': 'New Rights'
+        }
+        res = Rights.insert(newRights)
+        self.assertEqual(res.source, 'other')
+        self.assertEqual(res.license, 'new_uri')
+        self.assertEqual(res.rights_statement, 'New Rights')


### PR DESCRIPTION
The rights data received from different sources varies greatly in both the level detail and structure. The previous version of the db management script stored this metadata in distinct fields on individual records (e.g. in a license field on an item row). This was insufficient to accurately track this rights informations for several reasons, among which is the need to be able to assign multiple dates to each rights assertion (such as a rights determination date along with the determined copyright date). 

Removing these metadata fields into a separate class allows for a more flexible treatment of these fields, which are:

- `source` the institution (or individual) responsible for assigning these rights. (TODO: Make this an `agent` relationship and track all rights assignments)
- `license` a field for storing a (preferably) URI for the rights assigned
- `rights_statement` a human-readable version of the license
- `rights_reason` the justification behind the how the rights were assigned.
- `dates` pertinent date fields for the rights assessment

With this class in place rights assessments can be accurately assigned to all components of a work record in the SFR database. Importantly this allows for conflicting rights information to be stored, which is especially important for instance records that may have a disputed status from multiple sources. While this makes no judgement on the rights status of a work/instance, it will allow staff to identify and assess records with potential conflicts.