### PR TITLE
Add hathi identifier

### DIFF
--- a/alembic/versions/92889e3da8fd_add_hathitrust_identifiers_table.py
+++ b/alembic/versions/92889e3da8fd_add_hathitrust_identifiers_table.py
@@ -1,0 +1,29 @@
+"""Add HathiTrust identifiers table
+
+Revision ID: 92889e3da8fd
+Revises: 844b6f4ed646
+Create Date: 2019-02-05 09:59:55.166085
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '92889e3da8fd'
+down_revision = '844b6f4ed646'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'hathi',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('value', sa.Unicode, nullable=False, index=True),
+        sa.Column('identifier_id', sa.Integer, sa.ForeignKey('identifiers.id'))
+    )
+
+
+def downgrade():
+    op.drop_table('hathi')

--- a/alembic/versions/92889e3da8fd_add_hathitrust_identifiers_table.py
+++ b/alembic/versions/92889e3da8fd_add_hathitrust_identifiers_table.py
@@ -7,6 +7,7 @@ Create Date: 2019-02-05 09:59:55.166085
 """
 from alembic import op
 import sqlalchemy as sa
+from datetime import datetime
 
 
 # revision identifiers, used by Alembic.
@@ -21,7 +22,9 @@ def upgrade():
         'hathi',
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('value', sa.Unicode, nullable=False, index=True),
-        sa.Column('identifier_id', sa.Integer, sa.ForeignKey('identifiers.id'))
+        sa.Column('identifier_id', sa.Integer, sa.ForeignKey('identifiers.id')),
+        sa.Column('date_created', sa.DateTime, default=datetime.now()),
+        sa.Column('date_modified', sa.DateTime, default=datetime.now(), onupdate=datetime.now())
     )
 
 

--- a/model/identifiers.py
+++ b/model/identifiers.py
@@ -44,7 +44,7 @@ class Hathi(Core, Base):
 
     identifier_id = Column(Integer, ForeignKey('identifiers.id'))
 
-    identifier = relationship('Identifier', back_populates='gutenberg')
+    identifier = relationship('Identifier', back_populates='hathi')
 
     def __repr__(self):
         return '<Hathi(value={})>'.format(self.value)
@@ -203,7 +203,7 @@ class Identifier(Base):
 
     # Related tables for specific identifier types
     gutenberg = relationship('Gutenberg', back_populates='identifier')
-    hathi = relationship('Hathi', back_populates='hathi')
+    hathi = relationship('Hathi', back_populates='identifier')
     oclc = relationship('OCLC', back_populates='identifier')
     lccn = relationship('LCCN', back_populates='identifier')
     isbn = relationship('ISBN', back_populates='identifier')
@@ -272,8 +272,9 @@ class Identifier(Base):
         raise an error if duplicate identifiers are found for a single
         type."""
         idenType = identifier['type']
+        idenTable = idenType if idenType is not None else 'generic'
         existing = session.query(model) \
-            .join('identifiers', idenType) \
+            .join('identifiers', idenTable) \
             .filter(cls.identifierTypes[idenType].value == identifier['identifier']) \
             .filter(model.id == recordID) \
             .all()

--- a/model/identifiers.py
+++ b/model/identifiers.py
@@ -36,6 +36,20 @@ ITEM_IDENTIFIERS = Table(
 )
 
 
+class Hathi(Core, Base):
+    """Table for HathiTrust Identifiers"""
+    __tablename__ = 'hathi'
+    id = Column(Integer, primary_key=True)
+    value = Column(Unicode, index=True)
+
+    identifier_id = Column(Integer, ForeignKey('identifiers.id'))
+
+    identifier = relationship('Identifier', back_populates='gutenberg')
+
+    def __repr__(self):
+        return '<Hathi(value={})>'.format(self.value)
+
+
 class Gutenberg(Core, Base):
     """Table for Gutenberg Identifiers"""
     __tablename__ = 'gutenberg'
@@ -189,6 +203,7 @@ class Identifier(Base):
 
     # Related tables for specific identifier types
     gutenberg = relationship('Gutenberg', back_populates='identifier')
+    hathi = relationship('Hathi', back_populates='hathi')
     oclc = relationship('OCLC', back_populates='identifier')
     lccn = relationship('LCCN', back_populates='identifier')
     isbn = relationship('ISBN', back_populates='identifier')
@@ -200,6 +215,7 @@ class Identifier(Base):
 
     identifierTypes = {
         'gutenberg': Gutenberg,
+        'hathi': Hathi,
         'oclc': OCLC,
         'owi': OWI,
         'lccn': LCCN,


### PR DESCRIPTION
Creates a new table in the database to hold identifiers taken from HathiTrust. These are standard identifiers with no special cases.

The two files here are the alembic migration that is run against the database and the updated identifier ORM for sqlalchemy. One thing that will need to be added will be documentation on how to run alembic migrations, especially new copies as the database, as initializing the database with the current ORM will include all of the alembic revisions. The database must first be "stamped" to initialize the alembic table and allow for the running of new migrations.