### PR TITLE
Query performance boost

### DIFF
--- a/alembic/versions/8283074df611_add_foreign_key_indexes.py
+++ b/alembic/versions/8283074df611_add_foreign_key_indexes.py
@@ -1,0 +1,163 @@
+"""Add foreign key indexes
+
+Revision ID: 8283074df611
+Revises: 58b5c31ba2e3
+Create Date: 2019-02-14 11:56:05.649112
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8283074df611'
+down_revision = '58b5c31ba2e3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('instance_works', 'instances', ['work_id'])
+    op.create_index('item_instances', 'items', ['instance_id'])
+
+    op.create_index('work_json', 'import_json', ['work_id'])
+
+
+    op.create_index('agent_alias', 'aliases', ['agent_id'])
+    
+    op.create_index('work_agents_work', 'agent_works', ['work_id'])
+    op.create_index('work_agents_agent', 'agent_works', ['agent_id'])
+    op.create_index('instance_agents_instance', 'agent_instances', ['instance_id'])
+    op.create_index('instance_agents_agent', 'agent_instances', ['agent_id'])
+    op.create_index('item_agents_item', 'agent_items', ['item_id'])
+    op.create_index('item_agents_agent', 'agent_items', ['agent_id'])
+    
+    op.create_index('work_identifiers_work', 'work_identifiers', ['work_id'])
+    op.create_index('work_identifiers_identifier', 'work_identifiers', ['identifier_id'])
+    op.create_index('instance_identifiers_instance', 'instance_identifiers', ['instance_id'])
+    op.create_index('instance_identifiers_identifier', 'instance_identifiers', ['identifier_id'])
+    op.create_index('item_identifiers_item', 'item_identifiers', ['item_id'])
+    op.create_index('item_identifiers_identifier', 'item_identifiers', ['identifier_id'])
+
+    op.create_index('hathi_id', 'hathi', ['identifier_id'])
+    op.create_index('gutenberg_id', 'gutenberg', ['identifier_id'])
+    op.create_index('lccn_id', 'lccn', ['identifier_id'])
+    op.create_index('lcc_id', 'lcc', ['identifier_id'])
+    op.create_index('ddc_id', 'ddc', ['identifier_id'])
+    op.create_index('isbn_id', 'hathi', ['identifier_id'])
+    op.create_index('issn_id', 'issn', ['identifier_id'])
+    op.create_index('oclc_id', 'oclc', ['identifier_id'])
+    op.create_index('owi_id', 'owi', ['identifier_id'])
+    op.create_index('generic_id', 'generic', ['identifier_id'])
+
+    op.create_index('work_subjects_subject', 'subject_works', ['subject_id'])
+    op.create_index('work_subjects_work', 'subject_works', ['work_id'])
+
+    op.create_index('work_dates_work', 'work_dates', ['work_id'])
+    op.create_index('work_dates_date', 'work_dates', ['date_id'])
+    op.create_index('instance_dates_instance', 'instance_dates', ['instance_id'])
+    op.create_index('instance_dates_date', 'instance_dates', ['date_id'])
+    op.create_index('item_dates_item', 'item_dates', ['item_id'])
+    op.create_index('item_dates_date', 'item_dates', ['date_id'])
+    op.create_index('agent_dates_agent', 'agent_dates', ['agent_id'])
+    op.create_index('agent_dates_date', 'agent_dates', ['date_id'])
+
+    op.create_index('work_measurements_work', 'work_measurements', ['work_id'])
+    op.create_index('work_measurements_measurement', 'work_measurements', ['measurement_id'])
+    op.create_index('instance_measurements_instance', 'instance_measurements', ['instance_id'])
+    op.create_index('instance_measurements_measurement', 'instance_measurements', ['measurement_id'])
+    op.create_index('item_measurements_item', 'item_measurements', ['item_id'])
+    op.create_index('item_measurements_measurement', 'item_measurements', ['measurement_id'])
+    
+    op.create_index('work_rights_work', 'work_rights', ['work_id'])
+    op.create_index('work_rights_rights', 'work_rights', ['rights_id'])
+    op.create_index('instance_rights_instance', 'instance_rights', ['instance_id'])
+    op.create_index('instance_rights_rights', 'instance_rights', ['rights_id'])
+    op.create_index('item_rights_item', 'item_rights', ['item_id'])
+    op.create_index('item_rights_rights', 'item_rights', ['rights_id'])
+
+    op.create_index('work_links_work', 'work_links', ['work_id'])
+    op.create_index('work_links_link', 'work_links', ['link_id'])
+    op.create_index('instance_links_instance', 'instance_links', ['instance_id'])
+    op.create_index('instance_links_link', 'instance_links', ['link_id'])
+    op.create_index('item_links_item', 'item_links', ['item_id'])
+    op.create_index('item_links_link', 'item_links', ['link_id'])
+
+    op.create_index('work_alt_titles_work', 'work_alt_titles', ['work_id'])
+    op.create_index('work_alt_titles_alt_title', 'work_alt_titles', ['title_id'])
+    op.create_index('instance_alt_titles_instance', 'instance_alt_titles', ['instance_id'])
+    op.create_index('instance_alt_titles_alt_title', 'instance_alt_titles', ['title_id'])
+
+    
+
+def downgrade():
+    op.drop_index('instance_works')
+    op.drop_index('item_instances')
+
+    op.drop_index('work_json')
+
+
+    op.drop_index('agent_alias')
+    
+    op.drop_index('work_agents_work')
+    op.drop_index('work_agents_agent')
+    op.drop_index('instance_agents_instance')
+    op.drop_index('instance_agents_agent')
+    op.drop_index('item_agents_item')
+    op.drop_index('item_agents_agent')
+    
+    op.drop_index('work_identifiers_work')
+    op.drop_index('work_identifiers_identifier')
+    op.drop_index('instance_identifiers_instance')
+    op.drop_index('instance_identifiers_identifier')
+    op.drop_index('item_identifiers_item')
+    op.drop_index('item_identifiers_identifier')
+
+    op.drop_index('hathi_id')
+    op.drop_index('gutenberg_id')
+    op.drop_index('lccn_id')
+    op.drop_index('lcc_id')
+    op.drop_index('ddc_id')
+    op.drop_index('isbn_id')
+    op.drop_index('issn_id')
+    op.drop_index('oclc_id')
+    op.drop_index('owi_id')
+    op.drop_index('generic_id')
+
+    op.drop_index('work_subjects_subject')
+    op.drop_index('work_subjects_work')
+
+    op.drop_index('work_dates_work')
+    op.drop_index('work_dates_date')
+    op.drop_index('instance_dates_instance')
+    op.drop_index('instance_dates_date')
+    op.drop_index('item_dates_item')
+    op.drop_index('item_dates_date')
+    op.drop_index('agent_dates_agent')
+    op.drop_index('agent_dates_date')
+
+    op.drop_index('work_measurements_work')
+    op.drop_index('work_measurements_measurement')
+    op.drop_index('instance_measurements_instance')
+    op.drop_index('instance_measurements_measurement')
+    op.drop_index('item_measurements_item')
+    op.drop_index('item_measurements_measurement')
+    
+    op.drop_index('work_rights_work')
+    op.drop_index('work_rights_rights')
+    op.drop_index('instance_rights_instance')
+    op.drop_index('instance_rights_rights')
+    op.drop_index('item_rights_item')
+    op.drop_index('item_rights_rights')
+
+    op.drop_index('work_links_work')
+    op.drop_index('work_links_link')
+    op.drop_index('instance_links_instance')
+    op.drop_index('instance_links_link')
+    op.drop_index('item_links_item')
+    op.drop_index('item_links_link')
+
+    op.drop_index('work_alt_titles_work')
+    op.drop_index('work_alt_titles_alt_title')
+    op.drop_index('instance_alt_titles_instance')
+    op.drop_index('instance_alt_titles_alt_title')

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -103,6 +103,8 @@ def importRecord(session, record):
                 'type': 'work',
                 'identifier': dbInstance.work.uuid.hex
             })
+        
+        return op, 'Instance #{}'.format(dbInstance.id)
 
     elif record['type'] == 'item':
         logger.info('Ingesting item record')
@@ -123,6 +125,8 @@ def importRecord(session, record):
             'type': 'work',
             'identifier': dbItem.instance.work.uuid.hex
         })
+
+        return op, 'Item #{}'.format(dbItem.id)
 
     elif record['type'] == 'access_report':
         logger.info('Ingest Accessibility Report')

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -77,14 +77,10 @@ def importRecord(session, record):
         # enhancement process. Specifically pass identifying information to
         # a Kinesis stream that will processed by the OCLC Classify service
         # and others
+
+        # TODO Only enhance if UUID has not been enhanced in the past N days
         if record['method'] == 'insert':
             queryWork(dbWork, dbWork.uuid.hex)
-
-        # Put Resulting identifier in SQS to be ingested into Elasticsearch
-        OutputManager.putQueue({
-            'type': record['type'],
-            'identifier': dbWork.uuid.hex
-        })
 
         return op, dbWork.uuid.hex
 
@@ -99,10 +95,6 @@ def importRecord(session, record):
             logger.error('Cannot update ElasticSearch record for orphan instance {}'.format(dbInstance.id))
         else:
             dbInstance.work.date_modified = datetime.now()
-            OutputManager.putQueue({
-                'type': 'work',
-                'identifier': dbInstance.work.uuid.hex
-            })
         
         return op, 'Instance #{}'.format(dbInstance.id)
 
@@ -121,10 +113,6 @@ def importRecord(session, record):
             session.flush()
         
         dbItem.instance.work.date_modified = datetime.now()
-        OutputManager.putQueue({
-            'type': 'work',
-            'identifier': dbItem.instance.work.uuid.hex
-        })
 
         return op, 'Item #{}'.format(dbItem.id)
 
@@ -136,8 +124,3 @@ def importRecord(session, record):
         
         if dbItem is not None:
             dbItem.instance.work.date_modified = datetime.now()
-            logger.debug('Updating ElasticSearch with access report for {}'.format(dbItem))
-            OutputManager.putQueue({
-                'type': 'work',
-                'identifier': dbItem.instance.work.uuid.hex
-            })

--- a/model/instance.py
+++ b/model/instance.py
@@ -107,8 +107,9 @@ class Instance(Core, Base):
         subjects = instance.pop('subjects', [])
 
 
-        existing = Identifier.getByIdentifier(Instance, session, identifiers)
-        if existing is not None:
+        existingID = Identifier.getByIdentifier(Instance, session, identifiers)
+        if existingID is not None:
+            existing = session.query(Instance).get(existingID)
             parentWork = existing.work
             if parentWork is None and work is not None:
                 existing.work = work

--- a/model/item.py
+++ b/model/item.py
@@ -153,10 +153,11 @@ class Item(Core, Base):
         rights = item.pop('rights', [])
         agents = item.pop('agents', [])
 
-        existing = Identifier.getByIdentifier(cls, session, identifiers)
+        existingID = Identifier.getByIdentifier(cls, session, identifiers)
 
-        if existing is not None:
+        if existingID is not None:
             logger.debug('Found existing item by identifier')
+            existing = session.query(Item).get(existingID)
             cls.update(
                 session,
                 existing,
@@ -297,12 +298,11 @@ class Item(Core, Base):
         identifier = aceReport.pop('identifier', None)
         instanceID = aceReport.pop('instanceID', None)
 
-        existing = None
         if identifier is not None:
-            existing = Identifier.getByIdentifier(cls, session, [identifier])
+            existingID = Identifier.getByIdentifier(cls, session, [identifier])
 
-        if existing is not None:
-
+        if existingID is not None:
+            existing = session.query(Item).get(existingID)
             violations = aceReport.pop('violations', [])
             aceReport['ace_version'] = aceReport.pop('aceVersion')
             aceReport['report_json'] = aceReport.pop('json')

--- a/model/work.py
+++ b/model/work.py
@@ -350,13 +350,13 @@ class Work(Core, Base):
         if primaryIdentifier is not None and primaryIdentifier['type'] == 'uuid':
             return Work.getByUUID(session, primaryIdentifier['identifier'])
 
-        existingWork = Identifier.getByIdentifier(Work, session, identifiers)
-        if existingWork:
-            return existingWork
+        existingWorkID = Identifier.getByIdentifier(Work, session, identifiers)
+        if existingWorkID:
+            return session.query(Work).get(existingWorkID)
         else:
-            existingInstance = Identifier.getByIdentifier(Instance, session, identifiers)
-            if existingInstance:
-                return existingInstance.work
+            existingInstanceID = Identifier.getByIdentifier(Instance, session, identifiers)
+            if existingInstanceID:
+                return session.query(Instance).get(existingInstanceID).work
 
     @classmethod
     def getByUUID(cls, session, recUUID):


### PR DESCRIPTION
Implement PostgreSQL query optimization to improve response time to queries. This is primarily relevant for indexing queries, when many records are loaded from the database at once.

Improvements include: 
- Addition of Foreign Key indexes on all secondary/many-to-many tables
- Replacement of `all()` with `one()` in many instances where only one record should be returned (With multiple record returns caught and handled)
- Simple existence queries returning only row `id`s that are transformed into full records only when necessary
- Removal of unnecessary SQS that were used for indexing purposes