### PR TITLE
SFR-310 Add volume field to instances table

### DIFF
--- a/alembic/versions/7793d28d3a3f_add_volume_field_to_instance_table.py
+++ b/alembic/versions/7793d28d3a3f_add_volume_field_to_instance_table.py
@@ -1,0 +1,24 @@
+"""Add volume field to instance table
+
+Revision ID: 7793d28d3a3f
+Revises: 43488754bd80
+Create Date: 2019-03-11 09:55:47.598260
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7793d28d3a3f'
+down_revision = '43488754bd80'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('instances', sa.Column('volume', sa.Unicode))
+
+
+def downgrade():
+    op.drop_column('instances', 'volume')

--- a/model/instance.py
+++ b/model/instance.py
@@ -41,6 +41,7 @@ class Instance(Core, Base):
     pub_place = Column(Unicode, index=True)
     edition = Column(Unicode)
     edition_statement = Column(Unicode)
+    volume = Column(Unicode, index=True)
     table_of_contents = Column(Unicode)
     copyright_date = Column(Date, index=True)
     extent = Column(Unicode)
@@ -107,8 +108,12 @@ class Instance(Core, Base):
         seriesPos = instance.pop('series_position', None)
         subjects = instance.pop('subjects', [])
 
-
-        existingID = Identifier.getByIdentifier(Instance, session, identifiers)
+        # Check for a matching instance by identifiers (and volume if present)
+        existingID = Instance.lookupInstance(
+            session,
+            identifiers,
+            instance.get('volume', None)    
+        )
         if existingID is not None:
             existing = session.query(Instance).get(existingID)
             parentWork = existing.work
@@ -150,6 +155,20 @@ class Instance(Core, Base):
             language=language
         )
         return newInstance, 'inserted'
+
+    @classmethod
+    def lookupInstance(cls, session, identifiers, volume):
+        """Query for an existing instance. Generally this will be returned
+        by a simple identifier match, but if we have volume data, check to
+        be sure that these are the same volume (generally only for) periodicals
+        """
+        existingID = Identifier.getByIdentifier(Instance, session, identifiers)
+        if existingID is not None and volume is not None:
+            existingVol = session.query(Instance.volume).get(existingID)
+            if existingVol != volume:
+                existingID = None
+
+        return existingID
 
     @classmethod
     def update(cls, session, existing, instance, **kwargs):

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from collections import namedtuple
+
+from model.instance import Instance
+
+
+class InstanceTest(unittest.TestCase):
+
+    def test_create_instance(self):
+        testInst = Instance()
+        testInst.title = 'Testing'
+        testInst.edition = '1st ed'
+
+        self.assertEqual(str(testInst), '<Instance(title=Testing, edition=1st ed, work=None)>')
+    @patch('model.instance.Identifier')
+    def test_instance_lookup_new(self, mock_identifier):
+        mock_session = MagicMock()
+        mock_identifier.getByIdentifier.return_value = None
+
+        res = Instance.lookupInstance(mock_session, ['identifier'], None)
+        self.assertEqual(res, None)
+    
+    @patch('model.instance.Identifier')
+    def test_instance_lookup_existing(self, mock_identifier):
+        mock_session = MagicMock()
+        mock_session.query().get.return_value = 'vol'
+        mock_identifier.getByIdentifier.return_value = 1
+
+        res = Instance.lookupInstance(mock_session, ['identifier'], 'vol')
+        self.assertEqual(res, 1)
+
+    @patch('model.instance.Identifier')
+    def test_instance_lookup_new_volume(self, mock_identifier):
+        mock_session = MagicMock()
+        mock_session.query().get.return_value = 'other_vol'
+        mock_identifier.getByIdentifier.return_value = 1
+
+        res = Instance.lookupInstance(mock_session, ['identifier'], 'vol')
+        self.assertEqual(res, None)
+    
+    @patch('model.instance.Identifier')
+    @patch('model.instance.Instance')
+    def test_instance_insert(self, mock_instance, mock_identifier):
+        mock_instance.lookupInstance.return_value = None
+        mock_instance.insert.return_value = 'new_instance'
+
+        testInst, testOp = Instance.updateOrInsert('session', {})
+        self.assertEqual(testInst, 'new_instance')
+        self.assertEqual(testOp, 'inserted')
+    
+    @patch('model.instance.Identifier')
+    @patch('model.instance.Instance')
+    def test_instance_update(self, mock_instance, mock_identifier):
+        mock_instance.lookupInstance.return_value = 1
+        mock_session = MagicMock()
+        mock_existing = MagicMock()
+        mock_session.query().get.return_value = mock_existing
+
+        testInst, testOp = Instance.updateOrInsert(mock_session, {})
+        self.assertEqual(testInst, mock_existing)
+        self.assertEqual(testOp, 'updated')
+    
+    @patch('model.instance.Identifier')
+    @patch('model.instance.Instance')
+    def test_instance_update_work(self, mock_instance, mock_identifier):
+        mock_instance.lookupInstance.return_value = 1
+        mock_session = MagicMock()
+        mock_existing = MagicMock()
+        mock_work = MagicMock()
+        mock_existing.work = None
+        mock_session.query().get.return_value = mock_existing
+
+        testInst, testOp = Instance.updateOrInsert(mock_session, {}, mock_work)
+        self.assertEqual(testInst, mock_existing)
+        self.assertEqual(mock_existing.work, mock_work)
+        self.assertEqual(testOp, 'updated')


### PR DESCRIPTION
Add a volume field to the instance table that can be used to help
with lookup, in addition to providing a better place for storing
volume data associated with periodicals.

This also includes a new test class for instances as well as a few
cosmetic improvements to the instance class