### PR TITLE
Add redis cache

### DIFF
--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -1,7 +1,6 @@
 import json
 import os
 import redis
-import elasticache_auto_discovery
 from datetime import datetime, timedelta
 
 from helpers.errorHelpers import OutputError

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -83,6 +83,10 @@ class OutputManager():
     @classmethod
     def checkRecentQueries(cls, queryString):
         queryTime = cls.REDIS_CLIENT.get(queryString)
+        logger.debug('Checking query recency of {} at {}'.format(
+            queryString,
+            queryTime
+        ))
         currentTime = datetime.utcnow() - timedelta(days=1)
         if  (
                 queryTime is not None and

--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -80,7 +80,7 @@ def getAuthors(agentWorks):
 
 def createClassifyQuery(classifyQuery, queryType, uuid):
     queryStr = [value for key, value in classifyQuery.items()]
-    if OutputManager.checkRecentQueries('{}'.format('/'.join(queryStr))):
+    if OutputManager.checkRecentQueries('{}'.format('/'.join(queryStr))) is False:
         OutputManager.putKinesis({
             'type': queryType,
             'uuid': uuid,

--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -1,5 +1,5 @@
 import os
-import redis
+
 from lib.outputManager import OutputManager
 from helpers.logHelpers import createLog
 

--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -35,7 +35,7 @@ def queryWork(work, workUUID):
             'title': work.title,
             'authors': authors
         }
-        createClassifyQuery(workTitleFields, 'titleauthor', workUUID)
+        createClassifyQuery(workTitleFields, 'authorTitle', workUUID)
     else:
         # Otherwise, pass all valid identifiers to the Classify service
         for idType, ids in lookupIDs.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 psycopg2-binary
 pycountry
 pyyaml
+redis
 SQLAlchemy

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,34 @@
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+from collections import namedtuple
+
+from lib.outputManager import OutputManager
+
+
+class OutputTest(unittest.TestCase):
+
+    def test_connection_creation(self):
+        pass
+    
+    def test_redis_current(self):
+        OutputManager.REDIS_CLIENT.set(
+            'test/value',
+            datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+        )
+        res = OutputManager.checkRecentQueries('test/value')
+        self.assertEqual(res, True)
+    
+    def test_redis_missing(self):
+        OutputManager.REDIS_CLIENT.delete('test/value')
+        res = OutputManager.checkRecentQueries('test/value')
+        self.assertEqual(res, False)
+    
+    def test_redis_old(self):
+        oldDate = datetime.utcnow() - timedelta(days=2)
+        OutputManager.REDIS_CLIENT.set(
+            'test/value',
+            oldDate.strftime('%Y-%m-%dT%H:%M:%S')
+        )
+        res = OutputManager.checkRecentQueries('test/value')
+        self.assertEqual(res, False)


### PR DESCRIPTION
Implement a Redis cache to filter requests being made to the OCLC Classify service. Many of these requests can be duplicates, mainly from repeated entries in the HathiTrust database. Since the metadata returned for duplicate requests is redundant these requests can be skipped.

The Redis cache checks for each query in the past 24 hours, if older than that it is likely that an older record is being updated and new data should be fetched in case of updates. 

New unit tests have been added to cover the new methods.