### PR TITLE
Insert only refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # SFR Database Manager
-This is a Lambda function that manages writing updates to our postgres database instance. It will make updates where necessary (if a record already exists) or insert a new record. This relies on SQLAlchemy to manage the data model and Alembic to manage data migrations within the database. This allows for the tracking of data model changes over time and the ability to create new database instances.
+This is a Lambda function that manages writing new records to the ResearchNow/SFR postgres database instance. Any records where an existing match is found are deferred to the sfr-db-updater function, which implements additional logic for finding matches and merging records. This function is designed to quickly ingest new insert requests and start the data enrichment and ePub storage components of the data pipeline.
+
+This repository also contains the "source of truth" for the database model and migrations are defined in the `alembic` directory of this repository.
 
 ## Version
-v0.0.1
+v0.0.2
 
 ## Deployment
-This app is deployed via travisCI, with a pull request successfully building triggering a deployment to the relevant environment.
+This function (and other similar functions) rely on the `psycopg2-binary` library which requires a set of staticly linked libraries to be deployed on Linux. The Amazon AMI for Lambda functions does not automatically include these libraries and as a result cannot be deployed from non-Amazon linux environments. To properly deploy this and other functions, do so from either an EC2 instance created with the Amazon Linux image, or from a Docker container created in a similar fashion.
 
 ## Environment Variables
-A relatively large number of environment variables should be set to manage the various connections this function must make to read, store and output data to various sources:
 
 - LOG_LEVEL: Set the relevant log level (will appear in the cloudwatch logs)
 - DB_HOST: Host of our Postgresql instance
@@ -16,18 +17,27 @@ A relatively large number of environment variables should be set to manage the v
 - DB_NAME: Name of Postgresql database
 - DB_USER: User for specified database
 - DB_PASS: Password for above user
-- OUTPUT_SQS: URL for SQS queue where updated records are placed (see below for format)
 - EPUB_STREAM: Kinesis stream for parsing and local storage of ePub URLs
 - CLASSIFY_STREAM: Kinesis stream of work identifiers to be processed by the OCLC Classify service
 
-## Data Model and Message Formats
-With multiple interfaces, this function communicates in several different ways. It also contains the overall data model for the Postgresql database. Each of these is detailed at the links below
+## Dependencies
+- pycountry
+- pyscopg2-binary
+- pyyaml
+- redis
+- SQLAlchemy
+
+## Control Flow
+This function manages the overall control flow of the SFR/ResearchNow ingest pipeline and connects to several other Lambda functions, in addition to the central postgres instance. These are:
+1) The `sfr-db-updater` function via a Kinesis stream. This function is passed any records that update an existing row of the database.
+2) The `sfr-oclc-frbizer` function via a Kinesis stream. This handles the initial phase of the data enhancement process.
+3) The `sfr-epub-manager` function via a Kinesis stream. This handles storing any ePub files locally in S3, preparing them to be served by the front-end application.
 
 
-### Internal Formats
+### Data Model
 [Data Model](docs/datamodel.md)
 
-### Input/Output Formats
+## Input/Output Formats
 [Input Message Format](docs/inputformats.md)
 
 [Output Message Format](docs/outputformat.md)

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -14,6 +14,9 @@ The data model for the SFR project is closely modeled on the FRBR framework and 
 - [Measurements](#measurements)
 - [Identifiers](#identifiers)
 - [Links](#links)
+- [Dates](#dates)
+- [Rights](#rights)
+- [Languages](#languages)
 
 ## Works <a name="works"></a>
 The Work table is the highest level representation of a document in the SFR collection. It covers the intellectual content of a work, including the title, language, and other data that pertains to the the document as an abstract intellectual entity.
@@ -23,14 +26,10 @@ The Work table is the highest level representation of a document in the SFR coll
 - title (Unicode)
 - sort_title (Unicode)
 - sub_title (Unicode)
-- language (Char(2))
-- issued (Date)
-- published (Date)
-- license (Unicode)
-- rights_statement (Unicode)
 - medium (Unicode)
 - series (Unicode)
 - series_position (Integer)
+- summary (Unicode)
 
 ### Relationships
 - Agents
@@ -41,6 +40,8 @@ The Work table is the highest level representation of a document in the SFR coll
 - Identifiers
 - Measurements
 - Links
+- Dates
+- Languages
 
 ## Alternate Titles <a name="altTitles"></a>
 Each work can have multiple titles, and some works can have many such titles. Those are stored in a related table for flexibility purposes
@@ -69,21 +70,22 @@ The instance table covers, essentially, the edition-level metadata pertaining to
 - title (Unicode)
 - sub_title (Unicode)
 - pub_place (Unicode)
-- pub_date (Date)
 - edition (Unicode)
 - edition_statement (Unicode)
 - table_of_contents (Unicode)
-- copyright_date (Date)
-- language (Char(2))
-- work_id (Integer)
+- extent (Unicode)
+- volume (Unicode)
 
 ### Relationships
-- Works
+- Work
 - Items
 - Agents
 - Links
 - Measurements
 - Identifiers
+- Dates
+- Rights
+- Languages
 
 ## Items <a name="items"></a>
 Items represent specific copies of an instance/edition. In the case of SFR this indicates a specific digital copy of an ebook. These will generally be stored locally, however it will be possible for them to be accessed at a remote URL
@@ -91,17 +93,17 @@ Items represent specific copies of an instance/edition. In the case of SFR this 
 ### Fields
 - source (Unicode)
 - content_type (Unicode)
-- modified (Datetime)
 - drm (Unicode)
-- rights_uri (Unicode)
 
 ### Relationships
-- Instances
+- Instance
 - Agents
 - Identifiers
 - Measurements
 - Links
 - Accessibility Reports
+- Dates
+- Rights
 
 ## Accessibility Reports <a name="reports"></a>
 Each item (epub) is scored on its accessibility through the Ace Reporting tool. This data is stored and used to inform users about the overall accessibility of the epub file
@@ -124,14 +126,15 @@ These are individuals, organizations or families that are involved in the creati
 - lcnaf (Unicode)
 - viaf (Unicode)
 - biography (Unicode)
-- birth_date (Date)
-- death_date (Date)
+- roles (Unicode)
 
 ### Relationships
 - Works
 - Instances
 - Items
 - Links
+- Aliases
+- Dates
 
 ## Aliases <a name="aliases"></a>
 An agent may have name variations provided by different sources (but be uniquely identified by a VIAF or LCNAF identifier), and those variations should be stored for discovery purposes
@@ -200,3 +203,44 @@ These are references to external or internal resources that can be accessed via 
 - Instances
 - Items
 - Agents
+
+## Dates <a name="dates"></a>
+Individual dates or date ranges are held in this class so that records may contain any number of any type of date references. Dates are stored both as machine-parsable date ranges and as human-readable strings.
+
+### Fields
+- display_date (Unicode)
+- date_range (DateRange)
+- date_type (Unicode)
+
+### Relationships
+- Works
+- Instances
+- Items
+- Agents
+- Rights
+
+## Rights <a name="rights"></a>
+Copyright information pertaining to the bibliographic record being described. Rights data is generally associated with Instance records, but can also be associated with items, if a specific copy of a record has more restrictive controls placed on it (A CC 4.0 license for a specific copy of a public domain work, for example). Each rights object should contain a license URI along with a human-readable rights statement and, if possible, a justification for the rights determination.
+
+### Fields
+- source (Unicode)
+- license (Unicode)
+- rights_statement (Unicode)
+- rights_reason (Unicode)
+
+### Relationships
+- Instances
+- Items
+- Dates
+
+## Languages <a name="languages"></a>
+Individual language objects, including both the full representation of the language and the ISO 639-1/2 (2 and 3 character) language codes. These objects allow for both easy display and retrieval of language data. This ensures that multiple, normalized languages can be assigned to records within the database.
+
+### Fields
+- language (Unicode)
+- iso_2 (char(2))
+- iso_3 (char(3))
+
+### Relationships
+- Work
+- Instance

--- a/docs/outputformat.md
+++ b/docs/outputformat.md
@@ -1,16 +1,2 @@
-# Output Format
-The function ouputs record identifiers to an SQS stream. These records are then queued for indexing in ElasticSearch. This messaging format is drastically simpler than the input format as it only needs to identify the records to be updated.
-
-At present anytime any part of a record is updated, we update the whole record in ElasticSearch, so the only identifier passed through at this time is the UUID used to uniquely identify each work record.
-
-## Output Fields
-- Type: The type of record being updated. At present we are only allowing updates of work records (Which necessarily contains updates to all of that work's children records)
-- Identifier: The identifier of the record to update in the ElasticSearch index. Currently only work UUIDs are accepted by the indexer
-
-## Example
-```
-{
-  "type": "work",
-  "identifier": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-}
-```
+# ~~Output Format~~
+The output format for the db-manager is deprecated. The output formerly pushed records to an SQS stream that provided UUIDs to be updated in ElasticSearch. This has been replaced by a more effecient time-based polling strategy and at present there is no final output from this function.

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -7,6 +7,7 @@ from model.core import Base
 from model.work import Work
 from model.instance import Instance
 from model.item import Item
+from model.identifiers import Identifier
 
 from lib.queryManager import queryWork
 from lib.outputManager import OutputManager

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -67,57 +67,81 @@ def importRecord(session, record):
         if 'data' in workData:
             record = workData
             workData = workData['data']
-        op, dbWork = Work.updateOrInsert(session, workData)
+        
+        primaryID = workData.pop('primary_identifier', None)
+        workUUID = Work.lookupWork(session, workData['identifiers'], primaryID)
+        if workUUID is not None:
+            logger.info('Found exsting work {}. Placing record in update stream'.format(
+                workUUID
+            ))
+            workData['primary_identifier'] = {
+                'type': 'uuid',
+                'identifier': workUUID,
+                'weight': 1
+            }
+            # TODO Create stream and make configurable in env file
+            OutputManager.putKinesis(workData, 'sfr-db-update-development')
+            return 'Existing work {}'.format(workUUID)
 
-        if op == 'insert':
-            session.add(dbWork)
+        dbWork = Work.insert(session, workData)
 
-        # If this is a newly fetched record, retrieve additional data from the
-        # enhancement process. Specifically pass identifying information to
-        # a Kinesis stream that will processed by the OCLC Classify service
-        # and others
+        session.add(dbWork)
 
-        # TODO Only enhance if UUID has not been enhanced in the past N days
-        if record['method'] == 'insert':
-            queryWork(session, dbWork, dbWork.uuid.hex)
+        # queryWork(session, dbWork, dbWork.uuid.hex)
 
-        dbWork.date_modified = datetime.utcnow()
-        return op, dbWork.uuid.hex
+        return dbWork.uuid.hex
 
     elif record['type'] == 'instance':
         logger.info('Ingesting instance record')
         instanceData = record['data']
 
-        dbInstance, op = Instance.updateOrInsert(session, instanceData)
+        instanceID = Identifier.getByIdentifier(Instance, session, instanceData['identifiers'])
+        if instanceID is not None:
+            logger.info('Found exsting instance {}. Placing in update stream'.format(
+                instanceID
+            ))
+            instanceData['primary_identifier'] = {
+                'type': 'row_id',
+                'identifier': instanceID,
+                'weight': 1
+            }
+            return 'Existing instance Row ID {}'.format(instanceID)
 
-        if op is 'inserted':
-            logger.warning('Could not find existing record for instance {}'.format(dbInstance.id))
-            logger.error('Cannot update ElasticSearch record for orphan instance {}'.format(dbInstance.id))
-        else:
-            try:
-                dbInstance.work.date_modified = datetime.utcnow()
-            except AttributeError:
-                logger.error('Updating an orphan instance {}'.format(dbInstance.id))
+        dbInstance = Instance.insert(session, instanceData)
 
-        return op, 'Instance #{}'.format(dbInstance.id)
+        session.add(dbInstance)
+
+        dbInstance.work.date_modfied = datetime.utcnow()
+
+        return 'Instance #{}'.format(dbInstance.id)
 
     elif record['type'] == 'item':
         logger.info('Ingesting item record')
         itemData = record['data']
+        
+        itemID = Identifier.getByIdentifier(Item, session, itemData['identifiers'])
+        if itemID is not None:
+            logger.info('Found exsting item {}. Placing in update stream'.format(
+                itemID
+            ))
+            itemData['primary_identifier'] = {
+                'type': 'row_id',
+                'identifier': itemID,
+                'weight': 1
+            }
+            return 'Existing item Row ID {}'.format(itemID)
+
         instanceID = itemData.pop('instance_id', None)
 
-        dbItem, op = Item.updateOrInsert(session, itemData)
+        dbItem = Item.insert(session, itemData)
 
-        if op == 'inserted':
-            logger.debug('Got new item record, adding to instance')
-            # Add item to parent instance record
-            Instance.addItemRecord(session, instanceID, dbItem)
-            session.add(dbItem)
-            session.flush()
+        logger.debug('Got new item record, adding to instance')
+        Instance.addItemRecord(session, instanceID, dbItem)
+        session.add(dbItem)
         
         dbItem.instance.work.date_modified = datetime.utcnow()
 
-        return op, 'Item #{}'.format(dbItem.id)
+        return 'Item #{}'.format(dbItem.id)
 
     elif record['type'] == 'access_report':
         logger.info('Ingest Accessibility Report')

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -132,7 +132,7 @@ def importRecord(session, record):
 
         instanceID = itemData.pop('instance_id', None)
 
-        dbItem = Item.insert(session, itemData)
+        dbItem, op = Item.insert(session, itemData)
 
         logger.debug('Got new item record, adding to instance')
         Instance.addItemRecord(session, instanceID, dbItem)

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -104,7 +104,11 @@ def importRecord(session, record):
                 'identifier': instanceID,
                 'weight': 1
             }
-            OutputManager.putKinesis(instanceData, 'sfr-db-update-development')
+            OutputManager.putKinesis(
+                instanceData,
+                'sfr-db-update-development',
+                recType='instance'
+            )
             return 'Existing instance Row ID {}'.format(instanceID)
 
         dbInstance = Instance.insert(session, instanceData)
@@ -127,7 +131,11 @@ def importRecord(session, record):
                 'identifier': itemID,
                 'weight': 1
             }
-            OutputManager.putKinesis(itemData, 'sfr-db-update-development')
+            OutputManager.putKinesis(
+                itemData,
+                'sfr-db-update-development',
+                recType='item'
+            )
             return 'Existing item Row ID {}'.format(itemID)
 
         instanceID = itemData.pop('instance_id', None)

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -29,7 +29,7 @@ class OutputManager():
         pass
 
     @classmethod
-    def putKinesis(cls, data, stream):
+    def putKinesis(cls, data, stream, recType='work'):
         """Puts records into a Kinesis stream for processing by other parts of
         the SFR data pipeline. Takes data as an object and converts it into a
         JSON string. This is then passed to the specified stream.
@@ -40,7 +40,8 @@ class OutputManager():
         logger.info('Writing results to Kinesis')
         outputObject = {
             'status': 200,
-            'data': data
+            'data': data,
+            'type': recType
         }
 
         # The default lambda function here converts all objects into dicts

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -105,4 +105,13 @@ class OutputManager():
         """Converts an object or dict to a JSON string.
         the DEFAULT parameter implements a lambda function to get the values
         from an object using the vars() builtin."""
-        return json.dumps(obj, ensure_ascii=False, default=lambda x: vars(x))
+        try:
+            jsonStr = json.dumps(
+                obj, 
+                ensure_ascii=False, 
+                default=lambda x: vars(x)
+            )
+        except TypeError:
+            jsonStr = json.dumps(obj, ensure_ascii=False)
+
+        return jsonStr

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -46,11 +46,13 @@ class OutputManager():
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)
         
+        partKey = data['primary_identifier']['identifier']
+
         try:
             cls.KINESIS_CLIENT.put_record(
                 StreamName=stream,
                 Data=kinesisStream,
-                PartitionKey='0'
+                PartitionKey=partKey
             )
 
         except:

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -58,22 +58,19 @@ class OutputManager():
             raise OutputError('Failed to write result to output stream!')
 
     @classmethod
-    def putQueue(cls, data):
+    def putQueue(cls, data, outQueue):
         """This puts record identifiers into an SQS queue that is read for
         records to (re)index in ElasticSearch. Takes an object which is
         converted into a JSON string."""
 
         logger.info('Writing results to SQS')
-        outputObject = {
-            'type': data['type'],
-            'identifier': data['identifier']
-        }
+
         # The default lambda function here converts all objects into dicts
-        messageData = OutputManager._convertToJSON(outputObject)
+        messageData = OutputManager._convertToJSON(data)
 
         try:
             cls.SQS_CLIENT.send_message(
-                QueueUrl=os.environ['OUTPUT_SQS'],
+                QueueUrl=outQueue,
                 MessageBody=messageData
             )
         except:

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -46,7 +46,10 @@ class OutputManager():
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)
         
-        partKey = data['primary_identifier']['identifier']
+        try:
+            partKey = data['primary_identifier']['identifier']
+        except KeyError:
+            partKey = data['identifiers'][0]['identifier']    
 
         try:
             cls.KINESIS_CLIENT.put_record(

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -46,10 +46,7 @@ class OutputManager():
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)
         
-        try:
-            partKey = data['primary_identifier']['identifier']
-        except KeyError:
-            partKey = data['identifiers'][0]['identifier']    
+        partKey = OutputManager._createPartitionKey(data)
 
         try:
             cls.KINESIS_CLIENT.put_record(
@@ -117,3 +114,22 @@ class OutputManager():
             jsonStr = json.dumps(obj, ensure_ascii=False)
 
         return jsonStr
+    
+    @staticmethod
+    def _createPartitionKey(obj):
+        try:
+            return str(obj['primary_identifier']['identifier'])
+        except KeyError:
+            pass
+        
+        try:
+            return str(obj['identifiers'][0]['identifier'])
+        except KeyError:
+            pass
+        
+        try:
+            return str(obj['id'])
+        except KeyError:
+            pass
+        
+        return '0'

--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -97,11 +97,11 @@ def getAuthors(agentWorks):
 def createClassifyQuery(classifyQuery, queryType, uuid):
     queryStr = [value for key, value in classifyQuery.items()]
     if OutputManager.checkRecentQueries('{}'.format('/'.join(queryStr))) is False:
-        OutputManager.putKinesis({
+        OutputManager.putQueue({
             'type': queryType,
             'uuid': uuid,
             'fields': classifyQuery
-        }, os.environ['CLASSIFY_STREAM'])
+        }, os.environ['CLASSIFY_QUEUE'])
     else:
         logger.info('{} was recently queried, can skip Classify'.format(
             '/'.join(queryStr)

--- a/model/agent.py
+++ b/model/agent.py
@@ -125,10 +125,8 @@ class Agent(Core, Base):
                 existing.aliases.append(alias)
 
         if type(link) is dict:
-            updateLink = Link.updateOrInsert(session, link, Agent, existing.id)
-            if updateLink is not None:
-                existing.links.append(updateLink)
-        elif type(link) is list:
+            link = [link]
+        if link is not None:
             for linkItem in link:
                 updateLink = Link.updateOrInsert(session, linkItem, Agent, existing.id)
                 if updateLink is not None:
@@ -156,20 +154,15 @@ class Agent(Core, Base):
         dates = kwargs.get('dates', [])
 
         if aliases is not None:
-            for alias in list(map(lambda x: Alias(alias=x), aliases)):
-                agent.aliases.append(alias)
-
-        if type(link) is list:
-            for linkItem in link:
-                newLink = Link(**linkItem)
-                agent.links.append(newLink)
-        elif type(link) is dict:
-            newLink = Link(**link)
-            agent.links.append(newLink)
-
-        for date in dates:
-            newDate = DateField.insert(date)
-            agent.dates.append(newDate)
+            agent.aliases = [ Alias(alias=a) for a in aliases ]
+        
+        if type(link) is dict:
+            link = [link]
+        
+        if link is not None:
+            agent.links = [ Link(**l) for l in link ]
+        
+        agent.dates = [ DateField.insert(d) for d in dates ]
 
         return agent
 

--- a/model/agent.py
+++ b/model/agent.py
@@ -125,14 +125,11 @@ class Agent(Core, Base):
                 existing.aliases.append(alias)
 
         if type(link) is dict:
-            updateLink = Link.updateOrInsert(session, link, Agent, existing.id)
+            link = [link]
+        for linkItem in link:
+            updateLink = Link.updateOrInsert(session, linkItem, Agent, existing.id)
             if updateLink is not None:
                 existing.links.append(updateLink)
-        elif type(link) is list:
-            for linkItem in link:
-                updateLink = Link.updateOrInsert(session, linkItem, Agent, existing.id)
-                if updateLink is not None:
-                    existing.links.append(updateLink)
 
         for date in dates:
             updateDate = DateField.updateOrInsert(session, date, Agent, existing.id)
@@ -155,21 +152,13 @@ class Agent(Core, Base):
         link = kwargs.get('link', [])
         dates = kwargs.get('dates', [])
 
-        if aliases is not None:
-            for alias in list(map(lambda x: Alias(alias=x), aliases)):
-                agent.aliases.append(alias)
-
-        if type(link) is list:
-            for linkItem in link:
-                newLink = Link(**linkItem)
-                agent.links.append(newLink)
-        elif type(link) is dict:
-            newLink = Link(**link)
-            agent.links.append(newLink)
-
-        for date in dates:
-            newDate = DateField.insert(date)
-            agent.dates.append(newDate)
+        agent.aliases = [ Alias(alias=a) for a in aliases ]
+        
+        if type(link) is dict:
+            link = [link]    
+        agent.links = [ Link(**l) for l in link ]
+        
+        agent.dates = [ DateField.insert(d) for d in dates ]
 
         return agent
 

--- a/model/agent.py
+++ b/model/agent.py
@@ -126,18 +126,11 @@ class Agent(Core, Base):
 
         if type(link) is dict:
             link = [link]
-<<<<<<< HEAD
         if link is not None:
             for linkItem in link:
                 updateLink = Link.updateOrInsert(session, linkItem, Agent, existing.id)
                 if updateLink is not None:
                     existing.links.append(updateLink)
-=======
-        for linkItem in link:
-            updateLink = Link.updateOrInsert(session, linkItem, Agent, existing.id)
-            if updateLink is not None:
-                existing.links.append(updateLink)
->>>>>>> 2bcc95827260c7a81d660f4b642d14e67143d306
 
         for date in dates:
             updateDate = DateField.updateOrInsert(session, date, Agent, existing.id)
@@ -160,7 +153,6 @@ class Agent(Core, Base):
         link = kwargs.get('link', [])
         dates = kwargs.get('dates', [])
 
-<<<<<<< HEAD
         if aliases is not None:
             agent.aliases = [ Alias(alias=a) for a in aliases ]
         
@@ -169,13 +161,6 @@ class Agent(Core, Base):
         
         if link is not None:
             agent.links = [ Link(**l) for l in link ]
-=======
-        agent.aliases = [ Alias(alias=a) for a in aliases ]
-        
-        if type(link) is dict:
-            link = [link]    
-        agent.links = [ Link(**l) for l in link ]
->>>>>>> 2bcc95827260c7a81d660f4b642d14e67143d306
         
         agent.dates = [ DateField.insert(d) for d in dates ]
 

--- a/model/date.py
+++ b/model/date.py
@@ -103,33 +103,6 @@ class DateField(Core, Base):
         return '<Date(date={})>'.format(self.display_date)
 
     @classmethod
-    def updateOrInsert(cls, session, dateInst, model, recordID):
-        logger.debug('Inserting or updating date {}'.format(dateInst['display_date']))
-        """Query the database for a date on the current record. If found,
-        update the existing date, if not, insert new row"""
-        existing = DateField.lookupDate(session, dateInst, model, recordID)
-        if existing is not None:
-            logger.info('Updating existing date record {}'.format(existing.id))
-            DateField.update(existing, dateInst)
-            return None
-
-        logger.info('Inserting new date object')
-        return DateField.insert(dateInst)
-
-    @classmethod
-    def update(cls, existing, dateInst):
-        """Update fields on existing date"""
-        for field, value in dateInst.items():
-            if(
-                value is not None
-                and value.strip() != ''
-                and field != 'date_range'
-            ):
-                setattr(existing, field, value)
-
-        existing.date_range = DateField.parseDate(dateInst['date_range'])
-
-    @classmethod
     def insert(cls, dateData):
         """Insert a new date row"""
         dateInst = cls()
@@ -140,16 +113,6 @@ class DateField(Core, Base):
                 setattr(dateInst, field, DateField.parseDate(value))
 
         return dateInst
-
-    @classmethod
-    def lookupDate(cls, session, dateInst, model, recordID):
-        """Query database for link related to current record. Return link
-        if found, otherwise return None"""
-        return session.query(cls)\
-            .join(model.__tablename__)\
-            .filter(model.id == recordID)\
-            .filter(cls.date_type == dateInst['date_type'])\
-            .one_or_none()
 
     @staticmethod
     def parseDate(dateObj):

--- a/model/date.py
+++ b/model/date.py
@@ -103,6 +103,33 @@ class DateField(Core, Base):
         return '<Date(date={})>'.format(self.display_date)
 
     @classmethod
+    def updateOrInsert(cls, session, dateInst, model, recordID):
+        logger.debug('Inserting or updating date {}'.format(dateInst['display_date']))
+        """Query the database for a date on the current record. If found,
+        update the existing date, if not, insert new row"""
+        existing = DateField.lookupDate(session, dateInst, model, recordID)
+        if existing is not None:
+            logger.info('Updating existing date record {}'.format(existing.id))
+            DateField.update(existing, dateInst)
+            return None
+
+        logger.info('Inserting new date object')
+        return DateField.insert(dateInst)
+
+    @classmethod
+    def update(cls, existing, dateInst):
+        """Update fields on existing date"""
+        for field, value in dateInst.items():
+            if(
+                value is not None
+                and value.strip() != ''
+                and field != 'date_range'
+            ):
+                setattr(existing, field, value)
+
+        existing.date_range = DateField.parseDate(dateInst['date_range'])
+
+    @classmethod
     def insert(cls, dateData):
         """Insert a new date row"""
         dateInst = cls()
@@ -113,6 +140,16 @@ class DateField(Core, Base):
                 setattr(dateInst, field, DateField.parseDate(value))
 
         return dateInst
+
+    @classmethod
+    def lookupDate(cls, session, dateInst, model, recordID):
+        """Query database for link related to current record. Return link
+        if found, otherwise return None"""
+        return session.query(cls)\
+            .join(model.__tablename__)\
+            .filter(model.id == recordID)\
+            .filter(cls.date_type == dateInst['date_type'])\
+            .one_or_none()
 
     @staticmethod
     def parseDate(dateObj):

--- a/model/instance.py
+++ b/model/instance.py
@@ -82,6 +82,18 @@ class Instance(Core, Base):
         back_populates='instance'
     )
 
+    CHILD_FIELDS = [
+        'formats',
+        'agents',
+        'identifiers',
+        'measurements',
+        'dates',
+        'links',
+        'alt_titles',
+        'rights',
+        'language'
+    ]
+
     def __repr__(self):
         return '<Instance(title={}, edition={}, work={})>'.format(
             self.title,
@@ -90,226 +102,55 @@ class Instance(Core, Base):
         )
 
     @classmethod
-    def updateOrInsert(cls, session, instance, work=None):
-        """Check for existing instance, if found update that instance. If not
-        found, create a new record."""
-        items = instance.pop('formats', None)
-        agents = instance.pop('agents', None)
-        identifiers = instance.pop('identifiers', None)
-        measurements = instance.pop('measurements', None)
-        dates = instance.pop('dates', [])
-        links = instance.pop('links', [])
-        alt_titles = instance.pop('alt_titles', None)
-        rights = instance.pop('rights', [])
-        language = instance.pop('language', [])
-
-        # Get fields targeted for works
-        series = instance.pop('series', None)
-        seriesPos = instance.pop('series_position', None)
-        subjects = instance.pop('subjects', [])
-
-        # Check for a matching instance by identifiers (and volume if present)
-        existingID = Instance.lookupInstance(
-            session,
-            identifiers,
-            instance.get('volume', None)    
-        )
-        if existingID is not None:
-            existing = session.query(Instance).get(existingID)
-            parentWork = existing.work
-            if parentWork is None and work is not None:
-                existing.work = work
-                parentWork = work
-            try:
-                parentWork.updateFields(**{
-                    'series': series,
-                    'series_position': seriesPos
-                })
-                parentWork.importSubjects(session, subjects)
-            except AttributeError:
-                logger.warning('Matched orphan instance {}, cannot update parent'.format(
-                    str(existing.id)
-                ))
-            Instance.update(
-                session,
-                existing,
-                instance,
-                items=items,
-                agents=agents,
-                identifiers=identifiers,
-                measurements=measurements,
-                dates=dates,
-                links=links,
-                alt_titles=alt_titles,
-                rights=rights,
-                language=language
-            )
-            return existing, 'updated'
-
-        newInstance = Instance.insert(
-            session,
-            instance,
-            items=items,
-            agents=agents,
-            identifiers=identifiers,
-            measurements=measurements,
-            dates=dates,
-            links=links,
-            alt_titles=alt_titles,
-            rights=rights,
-            language=language
-        )
-        return newInstance, 'inserted'
+    def _buildChildDict(cls, instData):
+        return { field: instData.pop(field, []) for field in cls.CHILD_FIELDS }
 
     @classmethod
-    def lookupInstance(cls, session, identifiers, volume):
-        """Query for an existing instance. Generally this will be returned
-        by a simple identifier match, but if we have volume data, check to
-        be sure that these are the same volume (generally only for) periodicals
-        """
-        existingID = Identifier.getByIdentifier(Instance, session, identifiers)
-        if existingID is not None and volume is not None:
-            existingVol = session.query(Instance.volume).filter(Instance.id == existingID).one_or_none()
-            if existingVol != volume:
-                existingID = None
-
-        return existingID
-
-    @classmethod
-    def update(cls, session, existing, instance, **kwargs):
-        """Update an existing instance"""
-        identifiers = kwargs.get('identifiers', [])
-        measurements = kwargs.get('measurements', [])
-        items = kwargs.get('items', [])
-        agents = kwargs.get('agents', [])
-        altTitles = kwargs.get('alt_titles', [])
-        links = kwargs.get('links', [])
-        dates = kwargs.get('dates', [])
-        rights = kwargs.get('rights', [])
-        language = kwargs.get('language', [])
-
-        for field, value in instance.items():
-            if(value is not None):
-                setattr(existing, field, value)
-
-        for iden in identifiers:
-            try:
-                status, idenRec = Identifier.returnOrInsert(
-                    session,
-                    iden
-                )
-                if status == 'new':
-                    existing.identifiers.append(idenRec)
-                else:
-                    if Identifier.getIdentiferRelationship(
-                        session,
-                        idenRec,
-                        Instance,
-                        existing.id
-                    ) is None:
-                        existing.identifiers.append(idenRec)
-            except DataError as err:
-                logger.warning('Received invalid identifier')
-                logger.debug(err)
-
-        for measurement in measurements:
-            op, measurementRec = Measurement.updateOrInsert(
-                session,
-                measurement,
-                Instance,
-                existing.id
-            )
-            if op == 'insert':
-                existing.measurements.append(measurementRec)
-
-        for date in dates:
-            updateDate = DateField.updateOrInsert(session, date, Instance, existing.id)
-            if updateDate is not None:
-                existing.dates.append(updateDate)
-
-        for item in items:
-            # Check if the provided record contains an epub that can be stored
-            # locally. If it does, defer insert to epub creation process
-            itemRec, op = Item.createOrStore(session, item, existing.id)
-            if op == 'inserted':
-                existing.items.append(itemRec)
-
-        for agent in agents:
-            try:
-                agentRec, roles = Agent.updateOrInsert(session, agent)
-                if roles is None:
-                    roles = ['author']
-                for role in roles:
-                    if AgentInstances.roleExists(session, agentRec, role, existing.id) is None:
-                        AgentInstances(
-                            agent=agentRec,
-                            instance=existing,
-                            role=role
-                        )
-            except DataError:
-                logger.warning('Unable to read agent {}'.format(agent['name']))
-
-        for altTitle in list(filter(lambda x: AltTitle.insertOrSkip(session, x, Instance, existing.id), altTitles)):
-            existing.alt_titles.append(AltTitle(title=altTitle))
-
-        for link in links:
-            updateLink = Link.updateOrInsert(session, link, Instance, existing.id)
-            if updateLink is not None:
-                existing.links.append(updateLink)
-        
-        for rightsStmt in rights:
-            updateRights = Rights.updateOrInsert(
-                session,
-                rightsStmt,
-                Instance,
-                existing.id
-            )
-            if updateRights is not None:
-                existing.rights.append(updateRights)
-        
-        if isinstance(language, str) or language is None:
-            language = [language]
-
-        for lang in language:
-            try:
-                newLang = Language.updateOrInsert(session, lang)
-                langRel = Language.lookupRelLang(session, newLang, Instance, existing)
-                if langRel is None:
-                    existing.language.append(newLang)
-            except DataError:
-                logger.warning('Unable to parse language {}'.format(lang))
-
-        return existing
-
-    @classmethod
-    def insert(cls, session, instanceData, **kwargs):
+    def insert(cls, session, instanceData):
         """Insert a new instance record"""
-        logger.info('Inserting new instance record')
+        logger.info('Inserting new instance record {}'.format(
+            instanceData['title']
+        ))
+
+        childFields = Instance._buildChildDict(instanceData)
+        childFields['items'] = childFields.pop('formats', [])
+
+        # Remove fields intended for works (These should not be found here)
+        instanceData.pop('series', None)
+        instanceData.pop('series_position', None)
+        instanceData.pop('subjects', [])
+
         instance = Instance(**instanceData)
 
-        identifiers = kwargs.get('identifiers', [])
-        measurements = kwargs.get('measurements', [])
-        items = kwargs.get('items', [])
-        agents = kwargs.get('agents', [])
-        altTitles = kwargs.get('alt_titles', [])
-        links = kwargs.get('links', [])
-        dates = kwargs.get('dates', [])
-        rights = kwargs.get('rights', [])
-        language = kwargs.get('language', [])
+        Instance._addIdentifiers(session, instance, childFields['identifiers'])
 
-        if agents is not None:
-            try:
-                for agent in agents:
-                    agentRec, roles = Agent.updateOrInsert(session, agent)
-                    for role in roles:
-                        AgentInstances(
-                            agent=agentRec,
-                            instance=instance,
-                            role=role
-                        )
-            except DataError:
-                logger.warning('Unable to read agent {}'.format(agent['name']))
+        Instance._addAgents(session, instance, childFields['agents'])
 
+        Instance._addAltTitles(instance, childFields['alt_titles'])
+
+        Instance._addMeasurements(session, instance, childFields['measurements'])
+
+        Instance._addLinks(instance, childFields['links'])
+
+        Instance._addDates(instance, childFields['dates'])
+
+        Instance._addLanguages(session, instance, childFields['language'])
+
+        Instance._addRights(instance, childFields['rights'])
+
+        # We need to get the ID of the instance to allow for asynchronously
+        # storing the ePub file, so instance is added and flushed here
+        # TODO evaluate if this is a good idea, or can be handled better elsewhere
+        session.add(instance)
+        session.flush()
+
+        Instance._addItems(session, instance, childFields['items'])
+
+        logger.info('Inserted {}'.format(instance))
+        return instance
+
+    @classmethod
+    def _addIdentifiers(cls, session, instance, identifiers):
         for iden in identifiers:
             try:
                 status, idenRec = Identifier.returnOrInsert(
@@ -320,56 +161,76 @@ class Instance(Core, Base):
             except DataError as err:
                 logger.warning('Received invalid identifier')
                 logger.debug(err)
+    
+    @classmethod
+    def _addAgents(cls, session, instance, agents):
+        relsCreated = []
+        for agent in agents:
+            try:
+                agentRec, roles = Agent.updateOrInsert(session, agent)
+                for role in roles:
+                    if (agentRec.name, role) in relsCreated: continue
+                    relsCreated.append((agentRec.name, role))
+                    AgentInstances(
+                        agent=agentRec,
+                        instance=instance,
+                        role=role
+                    )
+            except DataError:
+                logger.warning('Unable to read agent {}'.format(agent['name']))
+    
+    @classmethod
+    def _addAltTitles(cls, instance, altTitles):
+        if altTitles is not None:
+            # Quick conversion to set to eliminate duplicate alternate titles
+            for altTitle in list(set(altTitles)):
+                instance.alt_titles.append(AltTitle(title=altTitle))
 
+    @classmethod
+    def _addMeasurements(cls, session, instance, measurements):
         for measurement in measurements:
             measurementRec = Measurement.insert(measurement)
             instance.measurements.append(measurementRec)
-
-        for altTitle in altTitles:
-            instance.alt_titles.append(AltTitle(title=altTitle))
-
+    
+    @classmethod
+    def _addLinks(cls, instance, links):
         for link in links:
             newLink = Link(**link)
             instance.links.append(newLink)
-
+    
+    @classmethod
+    def _addDates(cls, instance, dates):
         for date in dates:
             newDate = DateField.insert(date)
             instance.dates.append(newDate)
-        
+    
+    @classmethod
+    def _addLanguages(cls, session, instance, languages):
+        if languages is not None:
+            if isinstance(languages, str):
+                languages = [languages]
+            
+            for lang in languages:
+                try:
+                    newLang = Language.updateOrInsert(session, lang)
+                    instance.language.append(newLang)
+                except DataError:
+                    logger.debug('Unable to parse language {}'.format(lang))
+                    continue
+    
+    @classmethod
+    def _addRights(cls, instance, rights):
         for rightsStmt in rights:
             rightsDates = rightsStmt.pop('dates', [])
             newRights = Rights.insert(rightsStmt, dates=rightsDates)
             instance.rights.append(newRights)
-        
-        if isinstance(language, str) or language is None:
-            language = [language]
-        
-        for lang in language:
-            try:
-                newLang = Language.updateOrInsert(session, lang)
-                instance.language.append(newLang)
-            except DataError:
-                logger.debug('Unable to parse language {}'.format(lang))
-                continue
-
-        # We need to get the ID of the instance to allow for asynchronously
-        # storing the ePub file, so instance is added and flushed here
-        # TODO evaluate if this is a good idea, or can be handled better elsewhere
-        session.add(instance)
-        session.flush()
-
+    
+    @classmethod
+    def _addItems(cls, session, instance, items):
         for item in items:
             itemRec, op = Item.createOrStore(session, item, instance.id)
             if op == 'inserted':
                 instance.items.append(itemRec)
-        logger.info('Inserted {}'.format(instance))
-        return instance
-
-    @classmethod
-    def addItemRecord(cls, session, instanceID, itemRec):
-        instance = session.query(cls).get(instanceID)
-        instance.items.append(itemRec)
-
 
 class AgentInstances(Core, Base):
     """Table relating agents and instances. Is instantiated as a class to

--- a/model/instance.py
+++ b/model/instance.py
@@ -121,6 +121,7 @@ class Instance(Core, Base):
         instanceData.pop('subjects', [])
 
         instance = Instance(**instanceData)
+        session.add(instance)
 
         Instance._addIdentifiers(session, instance, childFields['identifiers'])
 
@@ -204,13 +205,13 @@ class Instance(Core, Base):
             if isinstance(languages, str):
                 languages = [languages]
             
-        for lang in languages:
-            try:
-                newLang = Language.updateOrInsert(session, lang)
-                instance.language.append(newLang)
-            except DataError:
-                logger.debug('Unable to parse language {}'.format(lang))
-                continue
+            for lang in languages:
+                try:
+                    newLang = Language.updateOrInsert(session, lang)
+                    instance.language.append(newLang)
+                except DataError:
+                    logger.debug('Unable to parse language {}'.format(lang))
+                    continue
     
     @classmethod
     def _addRights(cls, instance, rights):

--- a/model/item.py
+++ b/model/item.py
@@ -174,6 +174,7 @@ class Item(Core, Base):
         childFields = Item._buildChildDict(itemData)
 
         item = cls(**itemData)
+        session.add(item)
 
         Item._addIdentifiers(session, item, childFields['identifiers'])
 

--- a/model/item.py
+++ b/model/item.py
@@ -84,12 +84,25 @@ class Item(Core, Base):
         secondary=ITEM_LINKS,
         back_populates='items'
     )
-    
+
+    CHILD_FIELDS = [
+        'links',
+        'identifiers',
+        'measurements',
+        'dates',
+        'rights',
+        'agents'
+    ]
+
     def __repr__(self):
         return '<Item(source={}, instance={})>'.format(
             self.source,
             self.instance
         )
+
+    @classmethod
+    def _buildChildDict(cls, itemData):
+        return { field: itemData.pop(field, []) for field in cls.CHILD_FIELDS }
 
     @classmethod
     def createOrStore(cls, session, item, instanceID):
@@ -107,13 +120,16 @@ class Item(Core, Base):
                             cls.createLocalEpub(item, link, instanceID)
                             break
                 except TypeError as err:
-                    logger.warning('Found link {} with no url {}'.format(link, url))
+                    logger.warning('Found link {} with no url {}'.format(
+                        link,
+                        url
+                    ))
                     logger.debug(err)
             else:
                 item['links'].append(link)
         
         if len(item['links']) > 0:
-            return cls.updateOrInsert(session, item)
+            return cls.insert(session, item)
         else:
             return None, 'creating'
 
@@ -144,92 +160,49 @@ class Item(Core, Base):
         OutputManager.putKinesis(epubPayload, os.environ['EPUB_STREAM'])
 
     @classmethod
-    def updateOrInsert(cls, session, item):
-        """Will query for existing items and either update or insert an item
-        record pending the outcome of that query"""
-        links = item.pop('links', [])
-        identifiers = item.pop('identifiers', [])
-        measurements = item.pop('measurements', [])
-        dates = item.pop('dates', [])
-        rights = item.pop('rights', [])
-        agents = item.pop('agents', [])
-
-        existingID = Identifier.getByIdentifier(cls, session, identifiers)
-
-        if existingID is not None:
-            logger.debug('Found existing item by identifier')
-            existing = session.query(Item).get(existingID)
-            cls.update(
-                session,
-                existing,
-                item,
-                identifiers=identifiers,
-                links=links,
-                measurements=measurements,
-                dates=dates,
-                rights=rights,
-                agents=agents
-            )
-            return existing, 'updated'
-
-        logger.debug('Inserting new item record')
-        itemRec = cls.insert(
-            session,
-            item,
-            links=links,
-            measurements=measurements,
-            identifiers=identifiers,
-            dates=dates,
-            rights=rights,
-            agents=agents
-        )
-
-        return itemRec, 'inserted'
-
-    @classmethod
-    def insert(cls, session, itemData, **kwargs):
+    def insert(cls, session, itemData):
         """Insert a new item record"""
+
+        childFields = Item._buildChildDict(itemData)
+
         item = cls(**itemData)
 
-        links = kwargs.get('links', [])
-        measurements = kwargs.get('measurements', [])
-        identifiers = kwargs.get('identifiers', [])
-        dates = kwargs.get('dates', [])
-        rights = kwargs.get('rights', [])
-        agents = kwargs.get('agents', [])
+        Item._addIdentifiers(session, item, childFields['identifiers'])
 
-        for identifier in identifiers:
+        Item._addAgents(session, item, childFields['agents'])
+
+        Item._addMeasurements(session, item, childFields['measurements'])
+
+        Item._addLinks(item, childFields['links'])
+
+        Item._addDates(item, childFields['dates'])
+
+        Item._addRights(item, childFields['rights'])
+
+        return item, 'inserted'
+
+    @classmethod
+    def _addIdentifiers(cls, session, item, identifiers):
+        for iden in identifiers:
             try:
                 status, idenRec = Identifier.returnOrInsert(
                     session,
-                    identifier
+                    iden
                 )
                 item.identifiers.append(idenRec)
             except DataError as err:
                 logger.warning('Received invalid identifier')
                 logger.debug(err)
-
-        for link in links:
-            newLink = Link(**link)
-            item.links.append(newLink)
-
-        for measurement in measurements:
-            measurementRec = Measurement.insert(measurement)
-            item.measurements.append(measurementRec)
-
-        for date in dates:
-            newDate = DateField.insert(date)
-            item.dates.append(newDate)
-        
-        for rightsStmt in rights:
-            rightsDates = rightsStmt.pop('dates', [])
-            newRights = Rights.insert(rightsStmt, dates=rightsDates)
-            item.rights.append(newRights)
-
+    
+    @classmethod
+    def _addAgents(cls, session, item, agents):
+        relsCreated = []
         for agent in agents:
             try:
                 agentRec, roles = Agent.updateOrInsert(session, agent)
                 for role in roles:
+                    if (agentRec.name, role) in relsCreated: continue
+                    relsCreated.append((agentRec.name, role))
                     AgentItems(
                         agent=agentRec,
                         item=item,
@@ -237,90 +210,31 @@ class Item(Core, Base):
                     )
             except DataError:
                 logger.warning('Unable to read agent {}'.format(agent['name']))
-
-        return item
-
+    
     @classmethod
-    def update(cls, session, existing, item, **kwargs):
-        """Update an existing item record"""
-
-        links = kwargs.get('links', [])
-        measurements = kwargs.get('measurements', [])
-        identifiers = kwargs.get('identifiers', [])
-        dates = kwargs.get('dates', [])
-        rights = kwargs.get('rights', [])
-        agents = kwargs.get('agents', [])
-
-        for field, value in item.items():
-            if(value is not None and value.strip() != ''):
-                setattr(existing, field, value)
-
-        for identifier in identifiers:
-            try:
-                status, idenRec = Identifier.returnOrInsert(
-                    session,
-                    identifier
-                )
-                if status == 'new':
-                    existing.identifiers.append(idenRec)
-                else:
-                    if Identifier.getIdentiferRelationship(
-                        session,
-                        idenRec,
-                        Item,
-                        existing.id
-                    ) is None:
-                        existing.identifiers.append(idenRec)
-            except DataError as err:
-                logger.warning('Received invalid identifier')
-                logger.debug(err)
-
+    def _addMeasurements(cls, session, item, measurements):
         for measurement in measurements:
-            op, measurementRec = Measurement.updateOrInsert(
-                session,
-                measurement,
-                Item,
-                existing.id
-            )
-            if op == 'insert':
-                existing.measurements.append(measurementRec)
-
+            measurementRec = Measurement.insert(measurement)
+            item.measurements.append(measurementRec)
+    
+    @classmethod
+    def _addLinks(cls, item, links):
         for link in links:
-            existingLink = Link.lookupLink(session, link, cls, existing.id)
-            if existingLink is None:
-                existing.links.append(Link(**link))
-            else:
-                Link.update(existingLink, link)
-
+            newLink = Link(**link)
+            item.links.append(newLink)
+    
+    @classmethod
+    def _addDates(cls, item, dates):
         for date in dates:
-            updateDate = DateField.updateOrInsert(session, date, Item, existing.id)
-            if updateDate is not None:
-                existing.dates.append(updateDate)
-        
+            newDate = DateField.insert(date)
+            item.dates.append(newDate)
+    
+    @classmethod
+    def _addRights(cls, item, rights):
         for rightsStmt in rights:
-            updateRights = Rights.updateOrInsert(
-                session,
-                rightsStmt,
-                Item,
-                existing.id
-            )
-            if updateRights is not None:
-                existing.rights.append(updateRights)
-        
-        for agent in agents:
-            try:
-                agentRec, roles = Agent.updateOrInsert(session, agent)
-                if roles is None:
-                    roles = ['repository']
-                for role in roles:
-                    if AgentItems.roleExists(session, agentRec, role, existing.id) is None:
-                        AgentItems(
-                            agent=agentRec,
-                            item=existing,
-                            role=role
-                        )
-            except DataError:
-                logger.warning('Unable to read agent {}'.format(agent['name']))
+            rightsDates = rightsStmt.pop('dates', [])
+            newRights = Rights.insert(rightsStmt, dates=rightsDates)
+            item.rights.append(newRights)
 
     @classmethod
     def addReportData(cls, session, aceReport):

--- a/model/measurement.py
+++ b/model/measurement.py
@@ -98,54 +98,5 @@ class Measurement(Core, Base):
         )
 
     @classmethod
-    def updateOrInsert(cls, session, measure, model, recordID):
-
-        existingMeasure = Measurement.lookupMeasure(
-            session,
-            measure,
-            model,
-            recordID
-        )
-
-        if existingMeasure is not None:
-            updated = Measurement.update(measure, existingMeasure)
-            return 'update', updated
-
-        return 'insert', Measurement.insert(measure)
-
-    @classmethod
     def insert(cls, measure):
         return Measurement(**measure)
-
-    @classmethod
-    def update(cls, measure, existing):
-        for field in ['value', 'weight', 'taken_at']:
-            if measure[field] is not None:
-                setattr(existing, field, measure[field])
-
-        return existing
-
-    @classmethod
-    def lookupMeasure(cls, session, measure, model, recordID):
-        try:
-            return session.query(cls)\
-                .join(model.__tablename__[:-1])\
-                .filter(cls.quantity == measure['quantity'])\
-                .filter(cls.source_id == measure['source_id'])\
-                .filter(model.id == recordID)\
-                .one_or_none()
-        except MultipleResultsFound:
-            logger.error('Found duplicate measurement entries for {} {}'.format(
-                model.__tablename__,
-                recordID
-            ))
-            raise DataError('Duplicate measurement entries')
-    
-    @classmethod
-    def getMeasurements(cls, session, measure, model, recordID):
-        return session.query(cls.value)\
-            .join(model.__tablename__[:-1])\
-            .filter(cls.quantity == measure)\
-            .filter(model.id == recordID)\
-            .all()
-

--- a/model/work.py
+++ b/model/work.py
@@ -233,13 +233,13 @@ class Work(Core, Base):
             if isinstance(languages, str):
                 languages = [languages]
             
-            for lang in languages:
-                try:
-                    newLang = Language.updateOrInsert(session, lang)
-                    work.language.append(newLang)
-                except DataError:
-                    logger.debug('Unable to parse language {}'.format(lang))
-                    continue
+        for lang in languages:
+            try:
+                newLang = Language.updateOrInsert(session, lang)
+                work.language.append(newLang)
+            except DataError:
+                logger.debug('Unable to parse language {}'.format(lang))
+                continue
     
     @classmethod
     def lookupWork(cls, session, identifiers, primaryIdentifier=None):

--- a/model/work.py
+++ b/model/work.py
@@ -254,7 +254,7 @@ class Work(Core, Base):
         else:
             existingInstanceID = Identifier.getByIdentifier(Instance, session, identifiers)
             if existingInstanceID:
-                return session.query(Instance.work).get(existingInstanceID).work.uuid
+                return session.query(Instance).get(existingInstanceID).work.uuid
         
         return None
 

--- a/model/work.py
+++ b/model/work.py
@@ -129,6 +129,7 @@ class Work(Core, Base):
         childFields = Work._buildChildDict(workData)
 
         work = cls(**workData)
+        session.add(work)
         #
         # === IMPORTANT ===
         # This inserts a uuid value for the db row
@@ -140,9 +141,9 @@ class Work(Core, Base):
         jsonRec = RawData(data=childFields['storeJson'])
         work.import_json.append(jsonRec)
         
-        Work._addInstances(session, work, childFields['instances'])
-
         Work._addIdentifiers(session, work, childFields['identifiers'])
+        
+        Work._addInstances(session, work, childFields['instances'])
 
         Work._addAgents(session, work, childFields['agents'])
 
@@ -233,13 +234,13 @@ class Work(Core, Base):
             if isinstance(languages, str):
                 languages = [languages]
             
-        for lang in languages:
-            try:
-                newLang = Language.updateOrInsert(session, lang)
-                work.language.append(newLang)
-            except DataError:
-                logger.debug('Unable to parse language {}'.format(lang))
-                continue
+            for lang in languages:
+                try:
+                    newLang = Language.updateOrInsert(session, lang)
+                    work.language.append(newLang)
+                except DataError:
+                    logger.debug('Unable to parse language {}'.format(lang))
+                    continue
     
     @classmethod
     def lookupWork(cls, session, identifiers, primaryIdentifier=None):

--- a/model/work.py
+++ b/model/work.py
@@ -157,7 +157,7 @@ class Work(Core, Base):
 
         Work._addDates(work, childFields['dates'])
 
-        Work._addLanguages(work, session, childFields['language'])
+        Work._addLanguages(session, work, childFields['language'])
                 
         return work
     

--- a/service.py
+++ b/service.py
@@ -96,14 +96,15 @@ def parseRecord(encodedRec, session):
         raise DataError('Error in base64 encoding of record')
 
     try:
-        result = importRecord(session, record)
+        session.begin_nested() # Start transaction
+        record = importRecord(session, record)
+        session.commit()
+        return record
     except Exception as err:  # noqa: Q000
         # There are a large number of SQLAlchemy errors that can be thrown
         # These should be handled elsewhere, but this should catch anything
         # and rollback the session if we encounter something unexpected
-        session.rollback()
+        session.rollback() # Rollback current record only
         logger.error('Failed to store record')
         logger.debug(err)
         logger.debug(traceback.format_exc())
-        raise DBError('unknown', 'Unable to parse/ingest record, see logs for error')
-    return result

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -9,44 +9,6 @@ TestDate = namedtuple('TestDate', ['id', 'display_date', 'date_range', 'date_typ
 
 class TestDates(unittest.TestCase):
 
-    @patch('model.date.DateField.lookupDate', return_value=None)
-    @patch('model.date.DateField.insert', return_value=True)
-    def test_check_new(self, mock_insert, mock_lookup):
-        res = DateField.updateOrInsert('session', {'display_date': 'date'}, 'Date', 1)
-        mock_lookup.expect_to_be_called()
-        self.assertTrue(res)
-
-    td = TestDate(
-        id=1,
-        display_date='test',
-        date_range='[1,2)',
-        date_type='tester'
-    )
-    @patch('model.date.DateField.lookupDate', return_value=td)
-    @patch('model.date.DateField.update')
-    def test_check_existing(self, mock_update, mock_lookup):
-        res = DateField.updateOrInsert('session', {'display_date': 'date'}, 'Date', 1)
-        mock_lookup.expect_to_be_called()
-        mock_update.expect_to_be_called()
-        self.assertEqual(res, None)
-
-
-    @patch('model.date.DateField.parseDate', return_value='[3,4)')
-    def test_update_date(self, mock_parse):
-        newTest = DateField(
-            id=1,
-            display_date='test',
-            date_range='[1,2)',
-            date_type='tester'
-        )
-        newDate = {
-            'display_date': 'new',
-            'date_range': '[3,4)'
-        }
-        DateField.update(newTest, newDate)
-        self.assertEqual(newTest.display_date, 'new')
-        self.assertEqual(newTest.date_range, '[3,4)')
-
     @patch('model.date.DateField.parseDate', return_value='[3,4)')
     def test_insert_date(self, mock_parse):
         newDate = {

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,9 +1,12 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 from collections import namedtuple
 
-from model.instance import Instance
+from sqlalchemy.orm.exc import NoResultFound
 
+from model.instance import Instance, AgentInstances
+
+from helpers.errorHelpers import DataError, DBError
 
 class InstanceTest(unittest.TestCase):
 
@@ -13,65 +16,161 @@ class InstanceTest(unittest.TestCase):
         testInst.edition = '1st ed'
 
         self.assertEqual(str(testInst), '<Instance(title=Testing, edition=1st ed, work=None)>')
-    @patch('model.instance.Identifier')
-    def test_instance_lookup_new(self, mock_identifier):
-        mock_session = MagicMock()
-        mock_identifier.getByIdentifier.return_value = None
-
-        res = Instance.lookupInstance(mock_session, ['identifier'], None)
-        self.assertEqual(res, None)
     
-    @patch('model.instance.Identifier')
-    def test_instance_lookup_existing(self, mock_identifier):
-        mock_session = MagicMock()
-        mock_session.query().filter().one_or_none.return_value = 'vol'
-        mock_identifier.getByIdentifier.return_value = 1
+    def test_child_dict(self):
+        instanceData = {
+            'title': 'Testing',
+            'formats': ['item1', 'item2'],
+            'agents': ['agent1', 'agent2', 'agent3']
+        }
 
-        res = Instance.lookupInstance(mock_session, ['identifier'], 'vol')
-        self.assertEqual(res, 1)
-
-    @patch('model.instance.Identifier')
-    def test_instance_lookup_new_volume(self, mock_identifier):
-        mock_session = MagicMock()
-        mock_session.query().get.return_value = 'other_vol'
-        mock_identifier.getByIdentifier.return_value = 1
-
-        res = Instance.lookupInstance(mock_session, ['identifier'], 'vol')
-        self.assertEqual(res, None)
+        childFields = Instance._buildChildDict(instanceData)
+        self.assertEqual(childFields['formats'][1], 'item2')
+        self.assertEqual(len(childFields['agents']), 3)
+        self.assertEqual(instanceData['title'], 'Testing')
+        with self.assertRaises(KeyError):
+            instanceData['items']
     
-    @patch('model.instance.Identifier')
-    @patch('model.instance.Instance')
-    def test_instance_insert(self, mock_instance, mock_identifier):
-        mock_instance.lookupInstance.return_value = None
-        mock_instance.insert.return_value = 'new_instance'
-
-        testInst, testOp = Instance.updateOrInsert('session', {})
-        self.assertEqual(testInst, 'new_instance')
-        self.assertEqual(testOp, 'inserted')
-    
-    @patch('model.instance.Identifier')
-    @patch('model.instance.Instance')
-    def test_instance_update(self, mock_instance, mock_identifier):
-        mock_instance.lookupInstance.return_value = 1
+    def test_instance_insert(self):
         mock_session = MagicMock()
-        mock_existing = MagicMock()
-        mock_session.query().get.return_value = mock_existing
-
-        testInst, testOp = Instance.updateOrInsert(mock_session, {})
-        self.assertEqual(testInst, mock_existing)
-        self.assertEqual(testOp, 'updated')
-    
+        testData = {
+            'title': 'Testing'
+        }
+        testWork = Instance.insert(mock_session, testData)
+        self.assertEqual(testWork.title, 'Testing')
+        
     @patch('model.instance.Identifier')
-    @patch('model.instance.Instance')
-    def test_instance_update_work(self, mock_instance, mock_identifier):
-        mock_instance.lookupInstance.return_value = 1
-        mock_session = MagicMock()
-        mock_existing = MagicMock()
-        mock_work = MagicMock()
-        mock_existing.work = None
-        mock_session.query().get.return_value = mock_existing
+    def test_add_identifiers(self, mock_identifier):
+        mock_inst = MagicMock()
+        mock_inst.identifiers = []
 
-        testInst, testOp = Instance.updateOrInsert(mock_session, {}, mock_work)
-        self.assertEqual(testInst, mock_existing)
-        self.assertEqual(mock_existing.work, mock_work)
-        self.assertEqual(testOp, 'updated')
+        mock_identifier.returnOrInsert.side_effect = [
+            (0, 'test_identifier'),
+            DataError('testing')
+        ]
+
+        Instance._addIdentifiers('session', mock_inst, ['id1', 'id2'])
+        self.assertEqual(len(mock_inst.identifiers), 1)
+        self.assertEqual(mock_inst.identifiers[0], 'test_identifier')
+    
+    @patch('model.instance.Agent')
+    @patch('model.instance.AgentInstances')
+    def test_add_agents(self, mock_agent_instances, mock_agent):
+        mock_inst = MagicMock()
+        mock_inst.agents = []
+        mock_name = MagicMock()
+        mock_name.name = 'test_agent'
+        mock_agent.updateOrInsert.side_effect = [
+            (mock_name, ['tester']),
+            (mock_name, ['tester2', 'tester2']),
+            DataError('testing')
+        ]
+        test_agents = [
+            {'name': 'ag1'},
+            {'name': 'ag3'},
+            {'name': 'ag2'}
+        ]
+        Instance._addAgents('session', mock_inst, test_agents)
+        mock_agent_instances.assert_has_calls([
+            call(agent=mock_name, instance=mock_inst, role='tester'),
+            call(agent=mock_name, instance=mock_inst, role='tester2')
+        ])
+
+    @patch('model.instance.AltTitle')
+    def test_add_alt_title(self, mock_alt):
+        mock_inst = MagicMock()
+        mock_inst.alt_titles = []
+
+        mock_alt.return_value = 'test_title'
+
+        Instance._addAltTitles(mock_inst, ['alt1'])
+        self.assertEqual(mock_inst.alt_titles[0], 'test_title')
+    
+    @patch('model.instance.Measurement')
+    def test_add_measurement(self, mock_meas):
+        mock_inst = MagicMock()
+        mock_inst.measurements = []
+
+        mock_meas.insert.return_value = ('test_measure')
+
+        Instance._addMeasurements('session', mock_inst, ['measure1'])
+        self.assertEqual(mock_inst.measurements[0], 'test_measure')
+    
+    @patch('model.instance.Link')
+    def test_add_link(self, mock_link):
+        mock_inst = MagicMock()
+        mock_inst.links = []
+
+        mock_link.return_value = 'test_link'
+
+        Instance._addLinks(mock_inst, [MagicMock()])
+        self.assertEqual(mock_inst.links[0], 'test_link')
+    
+    @patch('model.instance.DateField')
+    def test_add_date(self, mock_date):
+        mock_inst = MagicMock()
+        mock_inst.dates = []
+
+        mock_date.insert.return_value = 'test_date'
+
+        Instance._addDates(mock_inst, ['1999-01-01'])
+        self.assertEqual(mock_inst.dates[0], 'test_date')
+    
+    @patch('model.instance.Language')
+    def test_add_languages(self, mock_lang):
+        mock_inst = MagicMock()
+        mock_inst.language = []
+
+        mock_lang.updateOrInsert.side_effect = [
+            'test_language',
+            DataError('testing')
+        ]
+
+        Instance._addLanguages('session', mock_inst, ['lang1', 'lang2'])
+        self.assertEqual(len(mock_inst.language), 1)
+        self.assertEqual(mock_inst.language[0], 'test_language')
+    
+    @patch('model.instance.Language')
+    def test_add_language_str(self, mock_lang):
+        mock_inst = MagicMock()
+        mock_inst.language = []
+
+        mock_lang.updateOrInsert.side_effect = [
+            'test_language',
+            DataError('testing')
+        ]
+
+        Instance._addLanguages('session', mock_inst, 'lang1')
+        self.assertEqual(len(mock_inst.language), 1)
+        self.assertEqual(mock_inst.language[0], 'test_language')
+    
+    @patch('model.instance.Rights')
+    def test_add_rights(self, mock_rights):
+        mock_inst = MagicMock()
+        mock_inst.rights = []
+
+        mock_rights.insert.return_value = 'test_rights'
+        testRights = {
+            'rights': 'rights1',
+            'dates': ['rd1']
+        }
+        Instance._addRights(mock_inst, [testRights])
+        self.assertEqual(mock_inst.rights[0], 'test_rights')
+    
+    @patch('model.instance.Item')
+    def test_add_items(self, mock_item):
+        mock_inst = MagicMock()
+        mock_inst.items = []
+
+        mock_item.createOrStore.return_value = ('test_item', 'inserted')
+
+        Instance._addItems('session', mock_inst, ['item1'])
+        self.assertEqual(mock_inst.items[0], 'test_item')
+    
+    def test_role_exists(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().filter().filter().one_or_none.return_value = 'test_role'
+        mock_agent = MagicMock()
+        mock_agent.id = 1
+        role = AgentInstances.roleExists(mock_session, mock_agent, 'role', 1)
+        self.assertEqual(role, 'test_role')

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -43,9 +43,14 @@ class ItemTest(unittest.TestCase):
                 }
             ]
         }
-        record, op = Item.createOrStore('session', testItem, 1)
+        mock_inst = MagicMock()
+        mock_inst.id = None
+        mock_session = MagicMock()
+        record, op = Item.createOrStore(mock_session, testItem, mock_inst)
         self.assertEqual(record, None)
         self.assertEqual(op, 'creating')
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_called_once()
 
     @patch('model.item.Item.insert', return_value=('test_item', 'test'))
     def test_create_store_store(self, mock_create):

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,206 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from collections import namedtuple
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from model.item import Item, AgentItems, AccessReport
+
+from helpers.errorHelpers import DataError, DBError
+
+class ItemTest(unittest.TestCase):
+
+    def test_create_item(self):
+        testItem = Item()
+        testItem.source = 'Testing'
+        testItem.instance_id = '1'
+
+        self.assertEqual(str(testItem), '<Item(source=Testing, instance=None)>')
+    
+    def test_child_dict(self):
+        itemData = {
+            'source': 'Testing',
+            'links': ['link1', 'link2'],
+            'agents': ['agent1', 'agent2', 'agent3']
+        }
+
+        childFields = Item._buildChildDict(itemData)
+        self.assertEqual(childFields['links'][1], 'link2')
+        self.assertEqual(len(childFields['agents']), 3)
+        self.assertEqual(itemData['source'], 'Testing')
+        with self.assertRaises(KeyError):
+            itemData['links']
+    
+    @patch('model.item.Item.createLocalEpub')
+    def test_create_store_create(self, mock_create):
+        testItem = {
+            'source': 'testing',
+            'links': [
+                {
+                    'url': 'gutenberg.org/ebooks/1.epub.images'
+                },{
+                    'url': None
+                }
+            ]
+        }
+        record, op = Item.createOrStore('session', testItem, 1)
+        self.assertEqual(record, None)
+        self.assertEqual(op, 'creating')
+
+    @patch('model.item.Item.insert', return_value=('test_item', 'test'))
+    def test_create_store_store(self, mock_create):
+        testItem = {
+            'source': 'testing',
+            'links': [
+                {
+                    'url': 'other.org/records/1'
+                }
+            ]
+        }
+        record, op = Item.createOrStore('session', testItem, 1)
+        self.assertEqual(record, 'test_item')
+        self.assertEqual(op, 'test')
+    
+    @patch.dict('os.environ', {'EPUB_STREAM': 'test-stream'})
+    @patch('model.item.OutputManager')
+    def test_create_epub(self, mock_out):
+        testItem = {
+            'source': 'testing',
+            'modified': '2019-01-01',
+            'measurements': [{
+                'quantity': 'bytes',
+                'value': 0
+            }]
+        }
+        testLink = {
+            'url': 'test_link'
+        }
+        Item.createLocalEpub(testItem, testLink, 1)
+        mock_out.putKinesis.assert_called_once()
+    
+    def test_item_insert(self):
+        mock_session = MagicMock()
+        testData = {
+            'source': 'Testing'
+        }
+        testWork, op = Item.insert(mock_session, testData)
+        self.assertEqual(testWork.source, 'Testing')
+        
+    @patch('model.item.Identifier')
+    def test_add_identifiers(self, mock_identifier):
+        mock_inst = MagicMock()
+        mock_inst.identifiers = []
+
+        mock_identifier.returnOrInsert.side_effect = [
+            (0, 'test_identifier'),
+            DataError('testing')
+        ]
+
+        Item._addIdentifiers('session', mock_inst, ['id1', 'id2'])
+        self.assertEqual(len(mock_inst.identifiers), 1)
+        self.assertEqual(mock_inst.identifiers[0], 'test_identifier')
+    
+    @patch('model.item.Agent')
+    @patch('model.item.AgentItems')
+    def test_add_agents(self, mock_agent_items, mock_agent):
+        mock_inst = MagicMock()
+        mock_inst.agents = []
+        mock_name = MagicMock()
+        mock_name.name = 'test_agent'
+        mock_agent.updateOrInsert.side_effect = [
+            (mock_name, ['tester']),
+            (mock_name, ['tester2', 'tester2']),
+            DataError('testing')
+        ]
+        test_agents = [
+            {'name': 'ag1'},
+            {'name': 'ag3'},
+            {'name': 'ag2'}
+        ]
+        Item._addAgents('session', mock_inst, test_agents)
+        mock_agent_items.assert_has_calls([
+            call(agent=mock_name, item=mock_inst, role='tester'),
+            call(agent=mock_name, item=mock_inst, role='tester2')
+        ])
+    
+    @patch('model.item.Measurement')
+    def test_add_measurement(self, mock_meas):
+        mock_inst = MagicMock()
+        mock_inst.measurements = []
+
+        mock_meas.insert.return_value = ('test_measure')
+
+        Item._addMeasurements('session', mock_inst, ['measure1'])
+        self.assertEqual(mock_inst.measurements[0], 'test_measure')
+    
+    @patch('model.item.Link')
+    def test_add_link(self, mock_link):
+        mock_inst = MagicMock()
+        mock_inst.links = []
+
+        mock_link.return_value = 'test_link'
+
+        Item._addLinks(mock_inst, [MagicMock()])
+        self.assertEqual(mock_inst.links[0], 'test_link')
+    
+    @patch('model.item.DateField')
+    def test_add_date(self, mock_date):
+        mock_inst = MagicMock()
+        mock_inst.dates = []
+
+        mock_date.insert.return_value = 'test_date'
+
+        Item._addDates(mock_inst, ['1999-01-01'])
+        self.assertEqual(mock_inst.dates[0], 'test_date')
+    
+    @patch('model.item.Rights')
+    def test_add_rights(self, mock_rights):
+        mock_inst = MagicMock()
+        mock_inst.rights = []
+
+        mock_rights.insert.return_value = 'test_rights'
+        testRights = {
+            'rights': 'rights1',
+            'dates': ['rd1']
+        }
+        Item._addRights(mock_inst, [testRights])
+        self.assertEqual(mock_inst.rights[0], 'test_rights')
+    
+    @patch('model.item.Identifier')
+    @patch('model.item.Measurement')
+    @patch('model.item.AccessReport', return_value=MagicMock())
+    def test_add_access_report(self, mock_report, mock_measure, mock_iden):
+        testReport = {
+            'identifier': 'item_id',
+            'instanceID': 'instance_id',
+            'violations': {
+                'testing': 1
+            },
+            'aceVersion': 'testing',
+            'json': 'json_string',
+            'timestamp': 'timestamp'
+        }
+        mock_iden.getByidentifier.return_value = 1
+        mock_session = MagicMock()
+        mock_item = MagicMock()
+        mock_item.access_reports = []
+        mock_session.query().get.return_value=mock_item
+        testItem = Item.addReportData(mock_session, testReport)
+        self.assertIsInstance(testItem, MagicMock)
+        mock_report.assert_called_once()
+        mock_measure.assert_called_once()
+    
+    def test_init_report(self):
+        testReport = AccessReport(
+            score=1,
+            item_id=1
+        )
+        self.assertEqual(str(testReport), '<AccessReport(score=1, item=None)>')
+
+    def test_role_exists(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().filter().filter().one_or_none.return_value = 'test_role'
+        mock_agent = MagicMock()
+        mock_agent.id = 1
+        role = AgentItems.roleExists(mock_session, mock_agent, 'role', 1)
+        self.assertEqual(role, 'test_role')

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -1,0 +1,247 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from collections import namedtuple
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from model.work import Work, AgentWorks
+from model.date import DateField
+
+from helpers.errorHelpers import DataError, DBError
+
+TestDate = namedtuple('TestDate', ['id', 'display_date', 'date_range', 'date_type'])
+
+class WorkTest(unittest.TestCase):
+
+    def test_work_init(self):
+        testWork = Work(
+            title='Testing',
+            summary='Summary'
+        )
+        self.assertEqual(testWork.summary, 'Summary')
+        self.assertEqual(str(testWork), '<Work(title=Testing)>')
+
+    def test_child_dict(self):
+        workData = {
+            'title': 'Testing',
+            'instances': ['instance1', 'instance2'],
+            'agents': ['agent1', 'agent2', 'agent3']
+        }
+
+        childFields = Work._buildChildDict(workData)
+        self.assertEqual(childFields['instances'][1], 'instance2')
+        self.assertEqual(len(childFields['agents']), 3)
+        self.assertEqual(workData['title'], 'Testing')
+        with self.assertRaises(KeyError):
+            workData['instances']
+
+    @patch('model.work.RawData', return_value=MagicMock())
+    def test_work_insert(self, mock_raw):
+        mock_session = MagicMock()
+        testData = {
+            'title': 'Testing'
+        }
+        testWork = Work.insert(mock_session, testData)
+        self.assertEqual(testWork.title, 'Testing')
+        self.assertNotEqual(testWork.uuid, '')
+
+    @patch('model.work.Instance')
+    def test_add_instance(self, mock_inst):
+        mock_work = MagicMock()
+        mock_work.instances = []
+
+        mock_inst.insert.return_value = 'test_instance'
+
+        Work._addInstances('session', mock_work, ['instance1'])
+        self.assertEqual(mock_work.instances[0], 'test_instance')
+    
+    @patch('model.work.Identifier')
+    def test_add_identifiers(self, mock_identifier):
+        mock_work = MagicMock()
+        mock_work.identifiers = []
+
+        mock_identifier.returnOrInsert.side_effect = [
+            (0, 'test_identifier'),
+            DataError('testing')
+        ]
+
+        Work._addIdentifiers('session', mock_work, ['id1', 'id2'])
+        self.assertEqual(len(mock_work.identifiers), 1)
+        self.assertEqual(mock_work.identifiers[0], 'test_identifier')
+    
+    @patch('model.work.Agent')
+    @patch('model.work.AgentWorks')
+    def test_add_agents(self, mock_agent_works, mock_agent):
+        mock_work = MagicMock()
+        mock_work.agents = []
+        mock_name = MagicMock()
+        mock_name.name = 'test_agent'
+        mock_agent.updateOrInsert.side_effect = [
+            (mock_name, ['tester']),
+            (mock_name, ['tester2', 'tester2']),
+            DataError('testing')
+        ]
+        test_agents = [
+            {'name': 'ag1'},
+            {'name': 'ag3'},
+            {'name': 'ag2'}
+        ]
+        Work._addAgents('session', mock_work, test_agents)
+        mock_agent_works.assert_has_calls([
+            call(agent=mock_name, work=mock_work, role='tester'),
+            call(agent=mock_name, work=mock_work, role='tester2')
+        ])
+
+    @patch('model.work.AltTitle')
+    def test_add_alt_title(self, mock_alt):
+        mock_work = MagicMock()
+        mock_work.alt_titles = []
+
+        mock_alt.return_value = 'test_title'
+
+        Work._addAltTitles(mock_work, ['alt1'])
+        self.assertEqual(mock_work.alt_titles[0], 'test_title')
+    
+    @patch('model.work.Subject')
+    def test_add_subject(self, mock_subj):
+        mock_work = MagicMock()
+        mock_work.subjects = []
+
+        mock_subj.updateOrInsert.return_value = (1, 'test_subject')
+
+        Work._addSubjects('session', mock_work, ['subject1'])
+        self.assertEqual(mock_work.subjects[0], 'test_subject')
+    
+    @patch('model.work.Measurement')
+    def test_add_measurement(self, mock_meas):
+        mock_work = MagicMock()
+        mock_work.measurements = []
+
+        mock_meas.insert.return_value = ('test_measure')
+
+        Work._addMeasurements('session', mock_work, ['measure1'])
+        self.assertEqual(mock_work.measurements[0], 'test_measure')
+    
+    @patch('model.work.Link')
+    def test_add_link(self, mock_link):
+        mock_work = MagicMock()
+        mock_work.links = []
+
+        mock_link.return_value = 'test_link'
+
+        Work._addLinks(mock_work, [MagicMock()])
+        self.assertEqual(mock_work.links[0], 'test_link')
+    
+    @patch('model.work.DateField')
+    def test_add_date(self, mock_date):
+        mock_work = MagicMock()
+        mock_work.dates = []
+
+        mock_date.insert.return_value = 'test_date'
+
+        Work._addDates(mock_work, ['1999-01-01'])
+        self.assertEqual(mock_work.dates[0], 'test_date')
+    
+    @patch('model.work.Language')
+    def test_add_languages(self, mock_lang):
+        mock_work = MagicMock()
+        mock_work.language = []
+
+        mock_lang.updateOrInsert.side_effect = [
+            'test_language',
+            DataError('testing')
+        ]
+
+        Work._addLanguages('session', mock_work, ['lang1', 'lang2'])
+        self.assertEqual(len(mock_work.language), 1)
+        self.assertEqual(mock_work.language[0], 'test_language')
+    
+    @patch('model.work.Language')
+    def test_add_language_str(self, mock_lang):
+        mock_work = MagicMock()
+        mock_work.language = []
+
+        mock_lang.updateOrInsert.side_effect = [
+            'test_language',
+            DataError('testing')
+        ]
+
+        Work._addLanguages('session', mock_work, 'lang1')
+        self.assertEqual(len(mock_work.language), 1)
+        self.assertEqual(mock_work.language[0], 'test_language')
+
+    @patch('model.work.Work.getByUUID', return_value='test_id')
+    def test_lookup_uuid(self, mock_get_uuid):
+        testID = Work.lookupWork('session', ['id1'], {
+            'type': 'uuid',
+            'identifier': 'test_uuid'
+        })
+        self.assertEqual(testID, 'test_id')
+    
+    @patch('model.work.Identifier')
+    def test_lookup_work(self, mock_iden):
+        mock_session = MagicMock()
+        mock_session.query().get().uuid = 'test_uuid'
+        mock_iden.getByIdentifier.return_value = 'test_id'
+        testID = Work.lookupWork(mock_session, ['id1'], None)
+        self.assertEqual(testID, 'test_uuid')
+    
+    @patch('model.work.Identifier')
+    def test_lookup_work_by_instance(self, mock_iden):
+        mock_session = MagicMock()
+        mock_session.query().get().work.uuid = 'test_uuid'
+        mock_iden.getByIdentifier.side_effect = [None, 'test_id']
+        testID = Work.lookupWork(mock_session, ['id1'], None)
+        self.assertEqual(testID, 'test_uuid')
+    
+    @patch('model.work.Identifier')
+    def test_lookup_work_not_found(self, mock_iden):
+        mock_session = MagicMock()
+        mock_session.query().get().work.uuid = 'test_uuid'
+        mock_iden.getByIdentifier.side_effect = [None, None]
+        testID = Work.lookupWork(mock_session, ['id1'], None)
+        self.assertEqual(testID, None)
+
+    @patch('model.work.uuid.UUID', return_value='test_uuid')
+    def test_get_by_uuid(self, mock_uuid):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.return_value = 'exist_uuid'
+        testUUID = Work.getByUUID(mock_session, 'uuid')
+        self.assertEqual(testUUID, 'exist_uuid')
+    
+    @patch('model.work.uuid.UUID', return_value='test_uuid')
+    def test_get_by_uuid_missing(self, mock_uuid):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.side_effect = NoResultFound
+        with self.assertRaises(DBError):
+            Work.getByUUID(mock_session, 'uuid')
+    
+    def test_create_agent_work(self):
+        testRec = AgentWorks(
+            work_id=1,
+            agent_id=1,
+            role='tester'
+        )
+        self.assertEqual(str(testRec), '<AgentWorks(work=1, agent=1, role=tester)>')
+    
+    def test_role_exists(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().filter().filter().one_or_none.return_value = 'test_role'
+        mock_agent = MagicMock()
+        mock_agent.id = 1
+        role = AgentWorks.roleExists(mock_session, mock_agent, 'role', 1)
+        self.assertEqual(role, 'test_role')
+
+    # Special test case to ensure that dates are handled properly
+    def test_date_backref(self):
+        testWork = Work()
+        tDate = DateField.insert({
+            'id': 1,
+            'display_date': 'January 1, 2019',
+            'date_range': '2019-01-01',
+            'date_type': 'test'
+        })
+        testWork.dates.append(tDate)
+        self.assertIsInstance(testWork, Work)
+        self.assertEqual(len(testWork.dates), 1)
+        self.assertEqual(testWork.dates[0].date_range, '[2019-01-01,)')


### PR DESCRIPTION
Greatly simplifies this repository by moving the functionality for updating existing database records to a separate repository and function. This leaves this function with the sole responsibility of inserting newly received records and referring existing records to the update function.

This still serves as the central "hub" of the SFR data pipeline, managing requests to other stages in the service, including the ePub ingest tool, OCLC enhancers and the updater.

Some update functions for subsidiary records are maintained here, including for things such as `Agents`, `Subjects`, and `Identifiers`, but `Works`, `Instances`, and `Items` are all insert-only. Further updates include:

- Conversion of the OCLC Classify output stream to an SQS queue for higher throughput
- Implementation of `TRANSACTION` based inserts for each individual record received. This allows for better `ROLLBACK`s to be executed on individual records.