### PR TITLE
Sfr 394 integrate viaf lookup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
   tests/*
   */site-packages/*
+  */distutils/*
 
 [report]
 exclude_lines =

--- a/model/date.py
+++ b/model/date.py
@@ -11,7 +11,7 @@ from sqlalchemy import (
     ForeignKey
 )
 from sqlalchemy.dialects.postgresql import DATERANGE
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql import text
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -91,7 +91,7 @@ class DateField(Core, Base):
     agents = relationship(
         'Agent',
         secondary=AGENT_DATES,
-        backref='dates'
+        backref=backref('dates', collection_class=set)
     )
     rights = relationship(
         'Rights',
@@ -108,13 +108,15 @@ class DateField(Core, Base):
         """Query the database for a date on the current record. If found,
         update the existing date, if not, insert new row"""
         existing = DateField.lookupDate(session, dateInst, model, recordID)
-        if existing is not None:
+        if existing is None:
+            logger.info('Inserting new date object')
+            outDate = DateField.insert(dateInst)
+        else:
             logger.info('Updating existing date record {}'.format(existing.id))
             DateField.update(existing, dateInst)
-            return None
+            outDate = existing
 
-        logger.info('Inserting new date object')
-        return DateField.insert(dateInst)
+        return outDate
 
     @classmethod
     def update(cls, existing, dateInst):

--- a/model/date.py
+++ b/model/date.py
@@ -121,15 +121,10 @@ class DateField(Core, Base):
     @classmethod
     def update(cls, existing, dateInst):
         """Update fields on existing date"""
-        for field, value in dateInst.items():
-            if(
-                value is not None
-                and value.strip() != ''
-                and field != 'date_range'
-            ):
-                setattr(existing, field, value)
-
-        existing.date_range = DateField.parseDate(dateInst['date_range'])
+        newRange = DateField.parseDate(dateInst['date_range'])
+        if newRange != existing.date_range:
+            existing.date_range = newRange
+            existing.display_date = dateInst['display_date']
 
     @classmethod
     def insert(cls, dateData):

--- a/model/link.py
+++ b/model/link.py
@@ -83,11 +83,13 @@ class Link(Core, Base):
         """Query the database for a link on the current record. If found,
         update the existing link, if not, insert new row"""
         existing = Link.lookupLink(session, link, model, recordID)
-        if existing is not None:
+        if existing is None:
+            outLink = Link(**link)
+        else:
             Link.update(existing, link)
-            return None
+            outLink = existing
 
-        return Link(**link)
+        return outLink
 
     @classmethod
     def update(cls, existing, link):

--- a/model/work.py
+++ b/model/work.py
@@ -206,28 +206,24 @@ class Work(Core, Base):
     
     @classmethod
     def _addSubjects(cls, session, work, subjects):
-        for subject in set(subjects):
+        for subject in subjects:
             op, subjectRec = Subject.updateOrInsert(session, subject)
             work.subjects.append(subjectRec)
 
     @classmethod
     def _addMeasurements(cls, session, work, measurements):
-        for measurement in measurements:
-            measurementRec = Measurement.insert(measurement)
-            work.measurements.append(measurementRec)
-    
+        work.measurements.extend(
+            [ Measurement.insert(m) for m in measurements ]
+        )
+
     @classmethod
     def _addLinks(cls, work, links):
-        for link in links:
-            newLink = Link(**link)
-            work.links.append(newLink)
-    
+        work.links.extend([ Link(**l) for l in links ])
+        
     @classmethod
     def _addDates(cls, work, dates):
-        for date in dates:
-            newDate = DateField.insert(date)
-            work.dates.append(newDate)
-    
+        work.dates.extend([ DateField.insert(d) for d in dates ])
+        
     @classmethod
     def _addLanguages(cls, session, work, languages):
         if languages is not None:

--- a/model/work.py
+++ b/model/work.py
@@ -206,7 +206,7 @@ class Work(Core, Base):
     
     @classmethod
     def _addSubjects(cls, session, work, subjects):
-        for subject in subjects:
+        for subject in set(subjects):
             op, subjectRec = Subject.updateOrInsert(session, subject)
             work.subjects.append(subjectRec)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ psycopg2-binary
 pycountry
 pyyaml
 redis
+requests
 SQLAlchemy

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -108,12 +108,16 @@ class TestAgent(unittest.TestCase):
             testInsert,
             aliases=['Name, Other'],
             link={'link': 'linker', 'link2': 'linker'},
-            dates=['date1', 'date2', 'date3']
+            dates=[
+                {'date_type': 'test', 'display': 'test'}, 
+                {'date_type': 'test2', 'display_date': 'test2'},    
+                {'date_type': 'test', 'display': 'test'} 
+            ]
         )
         self.assertEqual(outAgent.name, 'Name, New')
         self.assertEqual(outAgent.sort_name, 'Name, New')
         self.assertEqual(outAgent.aliases, set(['Name, Other']))
-        self.assertEqual(outAgent.dates, set(['date1', 'date2', 'date3']))
+        self.assertEqual(outAgent.dates, set(['date1', 'date2']))
 
 
     @patch('model.agent.Agent._findJaroWinklerQuery', return_value='mockAgent')

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -194,7 +194,7 @@ class TestAgent(unittest.TestCase):
     
     def test_authority_query_success(self):
         mock_session = MagicMock()
-        mock_session.query().filter().one.return_value = 'mockAgent'
+        mock_session.query().filter().one_or_none.return_value = 'mockAgent'
         testAgent = Agent._authorityQuery(
             mock_session,
             {
@@ -223,7 +223,7 @@ class TestAgent(unittest.TestCase):
     
     def test_authority_query_single_error(self):
         mock_session = MagicMock()
-        mock_session.query().filter().one.side_effect = NoResultFound
+        mock_session.query().filter().one_or_none.return_value = None
         testAgent = Agent._authorityQuery(
             mock_session,
             {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,26 +1,239 @@
 import unittest
 from unittest.mock import patch, call, MagicMock
 
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+from helpers.errorHelpers import DataError
 from model.agent import Agent
 
 
 class TestAgent(unittest.TestCase):
 
-    def test_agent_lookup_jw(self):
+    def test_agent_repr(self):
+        testAgent = Agent()
+        testAgent.name = 'Tester'
+        testAgent.sort_name = 'Tester'
+        self.assertEqual(
+            str(testAgent),
+            '<Agent(name=Tester, sort_name=Tester, lcnaf=None, viaf=None)>'
+        )
+    
+    @patch('model.agent.Agent._cleanName')
+    @patch('model.agent.Agent.lookupAgent', return_value=None)
+    @patch('model.agent.Agent.insert', return_value='newAgent')
+    def test_updateInsert_insert(self, mock_insert, mock_lookup, mock_clean):
+        mockAgent = {'name': 'Tester, Test', 'roles': None, 'dates': None}
+        testAgent, roles = Agent.updateOrInsert('session', mockAgent)
+        self.assertEqual(testAgent, 'newAgent')
+        self.assertEqual(roles, [])
+        mock_clean.called_once_with(mockAgent, [], [])
+        mock_lookup.called_once_with('session', mockAgent, [], [], [])
+        mock_insert.called_once_with(mockAgent, aliases=[], link=[], dates=[])
+    
+    @patch('model.agent.Agent._cleanName')
+    def test_updateInsert_noName(self, mock_clean):
+        mockAgent = {'name': ''}
+        try:
+            Agent.updateOrInsert('session', mockAgent)
+        except DataError:
+            pass
+        mock_clean.called_once_with(mockAgent, [], [])
+        self.assertRaises(DataError)
+
+    @patch('model.agent.Agent._cleanName')
+    @patch('model.agent.Agent.lookupAgent', return_value=1)
+    @patch('model.agent.Agent.update')
+    def test_updateInsert_update(self, mock_update, mock_lookup, mock_clean):
+        mockAgent = {'name': 'Tester, Test'}
         mock_session = MagicMock()
-        mock_session.query().filter().one.side_effect = [True]
+        mock_session.query().get.return_value = 'existingAgent'
+        testAgent, roles = Agent.updateOrInsert(mock_session, mockAgent)
+        self.assertEqual(testAgent, 'existingAgent')
+        self.assertEqual(roles, [])
+        mock_clean.called_once_with(mockAgent, [], [])
+        mock_lookup.called_once_with(mock_session, mockAgent, [], [], [])
+        mock_update.called_once_with(
+            mock_session,
+            'existingAgent',
+            mockAgent,
+            aliases=[],
+            link=[],
+            dates=[]
+        )
+
+    @patch('model.agent.Alias')
+    @patch('model.agent.Link')
+    @patch('model.agent.DateField')
+    def test_agent_update(self, mock_date, mock_link, mock_alias):
+        testUpdate = {'name': 'Name, New'}
+        testExisting = MagicMock()
+        testExisting.name = 'Name, Old'
+        testExisting.aliases = set()
+        testExisting.links = set()
+        testExisting.dates = set()
+        mock_alias.insertOrSkip.return_value = 'Name, Other'
+        mock_link.updateOrInsert.side_effect = ['link1']
+        mock_date.updateOrInsert.side_effect = ['date1', 'date2', 'date3']
+        Agent.update(
+            'session',
+            testExisting,
+            testUpdate,
+            aliases=['Name, Other'],
+            link={'link': 'linker', 'link2': 'linker'},
+            dates=['date1', 'date2', 'date3']
+        )
+        self.assertEqual(testExisting.name, 'Name, New')
+        self.assertEqual(testExisting.aliases, set(['Name, Other']))
+        self.assertEqual(testExisting.dates, set(['date1', 'date2', 'date3']))
+    
+    @patch('model.agent.Agent')
+    @patch('model.agent.Alias')
+    @patch('model.agent.Link')
+    @patch('model.agent.DateField')
+    def test_agent_insert(self, mock_date, mock_link, mock_alias, mock_agent):
+        testInsert = {'name': 'Name, New'}
+        mock_alias.return_value = 'Name, Other'
+        mock_link.side_effect = ['link1']
+        mock_date.insert.side_effect = ['date1', 'date2', 'date3']
+
+        mock_new = MagicMock()
+        mock_new.name = 'Name, New'
+        mock_new.sort_name = None
+        mock_new.aliases = set()
+        mock_new.links = set()
+        mock_new.dates = set()
+        mock_agent.return_value = mock_new
+
+        outAgent = Agent.insert(
+            testInsert,
+            aliases=['Name, Other'],
+            link={'link': 'linker', 'link2': 'linker'},
+            dates=['date1', 'date2', 'date3']
+        )
+        self.assertEqual(outAgent.name, 'Name, New')
+        self.assertEqual(outAgent.sort_name, 'Name, New')
+        self.assertEqual(outAgent.aliases, set(['Name, Other']))
+        self.assertEqual(outAgent.dates, set(['date1', 'date2', 'date3']))
+
+
+    @patch('model.agent.Agent._findJaroWinklerQuery', return_value='mockAgent')
+    @patch('model.agent.Agent._findViafQuery', return_value=None)
+    def test_agent_lookup_name(self, mock_viaf, mock_auth):
         testAgent = {
             'viaf': None,
             'lcnaf': None,
             'name': 'Tester, Test'
         }
-        res = Agent.lookupAgent(mock_session, testAgent)
-        self.assertTrue(res)       
+        res = Agent.lookupAgent('session', testAgent, [], [], [])
+        self.assertEqual(res, 'mockAgent')
+    
+    @patch('model.agent.Agent._authorityQuery', return_value='mockAgent')
+    def test_agent_lookup_authority(self, mock_auth):
+        testAgent = {
+            'viaf': 00000000,
+            'lcnaf': 00000000,
+            'name': 'Tester, Test'
+        }
+        res = Agent.lookupAgent('session', testAgent, [], [], [])
+        self.assertEqual(res, 'mockAgent')
+    
+    def test_jw_query_success(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.return_value = 'mockAgent'
+        testAgent = Agent._findJaroWinklerQuery(
+            mock_session,
+            {'name': 'O\'Tester, Test'}
+        )
+        self.assertEqual(testAgent, 'mockAgent')
+
+    def test_jw_query_multiple_error(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.side_effect = MultipleResultsFound
+        testAgent = Agent._findJaroWinklerQuery(
+            mock_session,
+            {'name': 'Tester, Test'}
+        )
+        self.assertEqual(testAgent, None)
+    
+    def test_jw_query_single_error(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.side_effect = NoResultFound
+        testAgent = Agent._findJaroWinklerQuery(
+            mock_session,
+            {'name': 'Tester, Test'}
+        )
+        self.assertEqual(testAgent, None)
+    
+    @patch('model.agent.requests')
+    @patch('model.agent.Agent._authorityQuery', return_value='matchedAgent')
+    @patch('model.agent.Agent._cleanName')
+    def test_viaf_query_success(self, mock_clean, mock_auth, mock_req):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'name': 'Test',
+            'viaf': 000,
+            'lcnaf': 000
+        }
+        mock_req.get.return_value = mock_resp
+        outAgent = Agent._findViafQuery('session', {'name': 'Old'}, [], [], [])
+        self.assertEqual(outAgent, 'matchedAgent')
+    
+    @patch('model.agent.requests')
+    def test_viaf_query_miss(self, mock_req):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'message': 'Missing'
+        }
+        mock_req.get.return_value = mock_resp
+        outAgent = Agent._findViafQuery('session', {'name': 'Old'}, [], [], [])
+        self.assertEqual(outAgent, None)
+    
+    def test_authority_query_success(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.return_value = 'mockAgent'
+        testAgent = Agent._authorityQuery(
+            mock_session,
+            {
+                'name': 'Tester, Test',
+                'viaf': 000,
+                'lcnaf': 000
+            }
+        )
+        self.assertEqual(testAgent, 'mockAgent')
+
+    def test_authority_query_multiple_error(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.side_effect = MultipleResultsFound
+        try:
+            Agent._authorityQuery(
+                mock_session,
+                {
+                    'name': 'Tester, Test',
+                    'viaf': 000,
+                    'lcnaf': 000
+                }
+            )
+        except MultipleResultsFound:
+            pass
+        self.assertRaises(MultipleResultsFound)
+    
+    def test_authority_query_single_error(self):
+        mock_session = MagicMock()
+        mock_session.query().filter().one.side_effect = NoResultFound
+        testAgent = Agent._authorityQuery(
+            mock_session,
+            {
+                'name': 'Tester, Test',
+                'viaf': 000,
+                'lcnaf': 000
+            }
+        )
+        self.assertEqual(testAgent, None)
 
     def test_clean_name(self):
         
         nameTest = {
-            'name': 'Test, Tester 1950-2000',
+            'name': '[Test, Tester 1950-2000]',
             'sort_name': '',
             'viaf': None,
             'lcnaf': None


### PR DESCRIPTION
Integrate the VIAF Lookup API into the database manager. This change shifts the burden for matching/merging agent records from fuzzy text within Postgres to an external service relying on VIAF and LCNAF authority numbers. This has multiple benefits:
- It provides for stronger matches using the authority numbers, while fuzzy string matching can easily fail.
- It provides a performance increase as the API lookup is faster and can be cached, while the fuzzy string matching must be performed every time an agent name is encountered
- This increases the total number of known VIAF/LCNAF numbers within the database, providing for better matching on all names in the future