### PR TITLE
SFR-660 importRecord refactor with cover block

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -10,7 +10,9 @@ environment_variables:
     DB_USER: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQEkoQNYODSk+m8cJJethF9fAAAAYTBfBgkqhkiG9w0BBwagUjBQAgEAMEsGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMRn26MsM9MH+2cXAyAgEQgB7gWCou8rWbTzfnj2dpcXupJEiP4FcYNo9x0b5Au44=
     DB_PSWD: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQF9q6qZdlshh6jj9SCwRnrxAAAAaTBnBgkqhkiG9w0BBwagWjBYAgEAMFMGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3VcD1csTm05LRnTxAgEQgCaaffMztl8n0z5ic66yft0nGxzX8141R/Y987kqXEeQYemN4DJ2zg==
 
+    UPDATE_STREAM: sfr-db-update-development
     EPUB_STREAM: sfr-epub-ingest-development
     CLASSIFY_QUEUE: https://sqs.us-east-1.amazonaws.com/224280085904/sfr-oclc-classify-development
+    COVER_QUEUE: https://sqs.us-east-1.amazonaws.com/224280085904/sfr-cover-processing
 
     VIAF_API: https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup?queryName=

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -1,134 +1,32 @@
-import os
-from datetime import datetime
-
-from sfrCore import Work, Instance, Item, Identifier
-
-from lib.queryManager import queryWork
-from lib.outputManager import OutputManager
+from lib.importers.workImporter import WorkImporter
+from lib.importers.instanceImporter import InstanceImporter
+from lib.importers.itemImporter import ItemImporter
+from lib.importers.accessImporter import AccessReportImporter
 
 from helpers.logHelpers import createLog
 
 logger = createLog('db_manager')
 
+# Load Updaters for specific types of records, all based on AbstractUpdater
+importers = {
+    'work': WorkImporter,
+    'instance': InstanceImporter,
+    'item': ItemImporter,
+    'access_report': AccessReportImporter,
+}
+
 
 def importRecord(session, record):
-    """Import a generic record. Fields within the record, type and method
-    control exactly what methods are invoked. Specifically this process will be
-    implemented to insert and update:
-    - works
-    - instances
-    - items
-    - agents
-    - subjects
-    - access_reports"""
-    if 'type' not in record:
-        record['type'] = 'work'
+    recordType = record.get('type', 'work')
+    logger.info('Updating {} record'.format(recordType))
 
-    if record['type'] == 'work':
-        workData = (record['data'])
-        if 'data' in workData:
-            record = workData
-            workData = workData['data']
-        
-        primaryID = workData.pop('primary_identifier', None)
-        work = Work.lookupWork(session, workData['identifiers'], primaryID)
-        if work is not None:
-            workUUID = work.uuid
-            logger.info('Found exsting work {}. Placing record in update stream'.format(
-                workUUID
-            ))
-            workData['primary_identifier'] = {
-                'type': 'uuid',
-                'identifier': workUUID.hex,
-                'weight': 1
-            }
-            # TODO Create stream and make configurable in env file
-            OutputManager.putKinesis(workData, 'sfr-db-update-development')
-            return 'Existing work {}'.format(workUUID)
-        dbWork = Work(session=session)
-        epubsToLoad = dbWork.insert(workData)
+    # Create specific importer
+    importer = importers[recordType](record, session)
+    action = importer.lookupRecord()
+    if action == 'insert':
+        importer.setInsertTime()
 
-        queryWork(session, dbWork, dbWork.uuid.hex)
-        for deferredEpub in epubsToLoad: 
-            OutputManager.putKinesis(
-                deferredEpub,
-                os.environ['EPUB_STREAM'],
-                recType='item'
-            )
-
-        return dbWork.uuid.hex
-
-    elif record['type'] == 'instance':
-        logger.info('Ingesting instance record')
-        instanceData = record['data']
-
-        instanceID = Identifier.getByIdentifier(Instance, session, instanceData['identifiers'])
-        if instanceID is not None:
-            logger.info('Found exsting instance {}. Placing in update stream'.format(
-                instanceID
-            ))
-            instanceData['primary_identifier'] = {
-                'type': 'row_id',
-                'identifier': instanceID,
-                'weight': 1
-            }
-            OutputManager.putKinesis(
-                instanceData,
-                'sfr-db-update-development',
-                recType='instance'
-            )
-            return 'Existing instance Row ID {}'.format(instanceID)
-
-        dbInstance, epubsToLoad = Instance.createNew(session, instanceData)
-
-        dbInstance.work.date_modfied = datetime.utcnow()
-
-        for deferredEpub in epubsToLoad: 
-            OutputManager.putKinesis(
-                deferredEpub,
-                os.environ['EPUB_STREAM'],
-                recType='item'
-            )
-
-        return 'Instance #{}'.format(dbInstance.id)
-
-    elif record['type'] == 'item':
-        logger.info('Ingesting item record')
-        itemData = record['data']
-        
-        itemID = Identifier.getByIdentifier(Item, session, itemData['identifiers'])
-        if itemID is not None:
-            logger.info('Found exsting item {}. Placing in update stream'.format(
-                itemID
-            ))
-            itemData['primary_identifier'] = {
-                'type': 'row_id',
-                'identifier': itemID,
-                'weight': 1
-            }
-            OutputManager.putKinesis(
-                itemData,
-                'sfr-db-update-development',
-                recType='item'
-            )
-            return 'Existing item Row ID {}'.format(itemID)
-
-        instanceID = itemData.pop('instance_id', None)
-
-        dbItem = Item.createItem(session, itemData)
-
-        logger.debug('Got new item record, adding to instance')
-        Instance.addItemRecord(session, instanceID, dbItem)
-        
-        dbItem.instance.work.date_modified = datetime.utcnow()
-
-        return 'Item #{}'.format(dbItem.id)
-
-    elif record['type'] == 'access_report':
-        logger.info('Ingest Accessibility Report')
-        reportData = record['data']
-
-        dbItem = Item.addReportData(session, reportData)
-        
-        if dbItem is not None:
-            dbItem.instance.work.date_modified = datetime.utcnow()
+    logger.info('{} {} #{}'.format(
+        action, recordType.upper(), importer.identifier
+    ))
+    return '{} {} #{}'.format(action, recordType.upper(), importer.identifier)

--- a/lib/importers/abstractImporter.py
+++ b/lib/importers/abstractImporter.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod, abstractproperty
+
+from helpers.logHelpers import createLog
+
+
+class AbstractImporter(ABC):
+    @abstractmethod
+    def __init__(self, record, session):
+        self.session = session
+        self.logger = self.createLogger()
+
+    @abstractproperty
+    def identifier(self):
+        return None
+
+    @abstractmethod
+    def lookupRecord(self):
+        return None
+
+    @abstractmethod
+    def insertRecord(self):
+        return None
+
+    @abstractmethod
+    def setInsertTime(self):
+        pass
+
+    def createLogger(self):
+        return createLog(type(self).__name__)

--- a/lib/importers/accessImporter.py
+++ b/lib/importers/accessImporter.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from sfrCore import Item
+
+from lib.importers.abstractImporter import AbstractImporter
+
+
+class AccessReportImporter(AbstractImporter):
+    def __init__(self, record, session):
+        self.data = record['data']
+        self.item = None
+        super().__init__(record, session)
+
+    @property
+    def identifier(self):
+        return self.item.id
+
+    def lookupRecord(self):
+        self.logger.info('Ingest Accessibility Report')
+
+        return self.insertRecord()
+
+    def insertRecord(self):
+        self.item = Item.addReportData(self.session, self.data)
+
+        if not self.item:
+            return 'error'
+
+        return 'insert'
+
+    def setInsertTime(self):
+        self.item.instance.work.date_modified = datetime.utcnow()

--- a/lib/importers/instanceImporter.py
+++ b/lib/importers/instanceImporter.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+import json
+import os
+from sfrCore import Instance, Identifier
+
+from lib.importers.abstractImporter import AbstractImporter
+from lib.outputManager import OutputManager
+
+
+class InstanceImporter(AbstractImporter):
+    def __init__(self, record, session):
+        self.data = record['data']
+        self.instance = None
+        super().__init__(record, session)
+
+    @property
+    def identifier(self):
+        return self.instance.id
+
+    def lookupRecord(self):
+        self.logger.info('Ingesting instance record')
+
+        instanceID = Identifier.getByIdentifier(
+            Instance,
+            self.session,
+            self.data.get('identifiers', [])
+        )
+        if instanceID is not None:
+            self.logger.info(
+                'Found existing instance {}. Placing in update stream'.format(
+                    instanceID
+                )
+            )
+            self.data['primary_identifier'] = {
+                'type': 'row_id',
+                'identifier': instanceID,
+                'weight': 1
+            }
+            OutputManager.putKinesis(
+                self.data,
+                os.environ['UPDATE_STREAM'],
+                recType='instance'
+            )
+            return 'update'
+
+        self.insertRecord()
+        return 'insert'
+
+    def insertRecord(self):
+        self.instance, epubsToLoad = Instance.createNew(
+            self.session, self.data
+        )
+
+        self.storeCovers()
+        self.storeEpubs(epubsToLoad)
+
+    def storeCovers(self):
+        for link in self.instance.links:
+            try:
+                linkFlags = json.loads(link.flags)
+            except TypeError:
+                linkFlags = link.flags
+
+            if linkFlags.get('cover', False) is True:
+                OutputManager.putQueue(
+                    {
+                        'url': link.url,
+                        'source': self.instance.items[0].source,
+                        'identifier': self.data['identifiers'][0]['identifier']
+                    },
+                    os.environ['COVER_QUEUE']
+                )
+
+    def storeEpubs(self, epubsToLoad):
+        for deferredEpub in epubsToLoad:
+            OutputManager.putKinesis(
+                deferredEpub,
+                os.environ['EPUB_STREAM'],
+                recType='item'
+            )
+
+    def setInsertTime(self):
+        self.instance.work.date_modified = datetime.utcnow()

--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+import os
+from sfrCore import Item, Instance, Identifier
+
+from lib.importers.abstractImporter import AbstractImporter
+from lib.outputManager import OutputManager
+
+
+class ItemImporter(AbstractImporter):
+    def __init__(self, record, session):
+        self.data = record['data']
+        self.item = None
+        super().__init__(record, session)
+
+    @property
+    def identifier(self):
+        return self.item.id
+
+    def lookupRecord(self):
+        self.logger.info('Ingesting item record')
+
+        itemID = Identifier.getByIdentifier(
+            Item,
+            self.session,
+            self.data.get('identifiers', [])
+        )
+        if itemID is not None:
+            self.logger.info(
+                'Found existing item {}. Sending to update stream'.format(
+                    itemID
+                )
+            )
+            self.data['primary_identifier'] = {
+                'type': 'row_id',
+                'identifier': itemID,
+                'weight': 1
+            }
+            OutputManager.putKinesis(
+                self.data,
+                os.environ['UPDATE_STREAM'],
+                recType='item'
+            )
+            return 'update'
+
+        self.logger.info('Ingesting item record')
+
+        self.insertRecord()
+        return 'insert'
+
+    def insertRecord(self):
+        instanceID = self.data.pop('instance_id', None)
+
+        self.item = Item.createItem(self.session, self.data)
+
+        self.logger.debug('Got new item record, adding to instance')
+        Instance.addItemRecord(self.session, instanceID, self.item)
+
+    def setInsertTime(self):
+        self.item.instance.work.date_modified = datetime.utcnow()

--- a/lib/importers/workImporter.py
+++ b/lib/importers/workImporter.py
@@ -1,0 +1,88 @@
+import json
+import os
+from sfrCore import Work
+
+from lib.importers.abstractImporter import AbstractImporter
+from lib.queryManager import queryWork
+from lib.outputManager import OutputManager
+
+
+class WorkImporter(AbstractImporter):
+    def __init__(self, record, session):
+        self.data = WorkImporter.parseData(record)
+        self.work = None
+        super().__init__(record, session)
+
+    @staticmethod
+    def parseData(record):
+        workData = (record['data'])
+        if 'data' in workData:
+            workData = workData['data']
+        return workData
+
+    @property
+    def identifier(self):
+        return self.work.uuid.hex
+
+    def lookupRecord(self):
+        primaryID = self.data.pop('primary_identifier', None)
+        self.work = Work.lookupWork(
+            self.session,
+            self.data.get('identifiers', []),
+            primaryID
+        )
+        if self.work is not None:
+            self.logger.info(
+                'Found existing work {}. Sending to update stream'.format(
+                    self.work.uuid.hex
+                )
+            )
+            self.data['primary_identifier'] = {
+                'type': 'uuid',
+                'identifier': self.work.uuid.hex,
+                'weight': 1
+            }
+
+            OutputManager.putKinesis(self.data, os.environ['UPDATE_STREAM'])
+            return 'update'
+
+        self.insertRecord()
+        return 'insert'
+
+    def insertRecord(self):
+        self.work = Work(session=self.session)
+        epubsToLoad = self.work.insert(self.data)
+        # Kicks off enhancement pipeline through OCLC CLassify
+        queryWork(self.session, self.work, self.work.uuid.hex)
+
+        self.storeCovers()
+        self.storeEpubs(epubsToLoad)
+
+    def storeCovers(self):
+        for instance in self.work.instances:
+            for link in instance.links:
+                try:
+                    linkFlags = json.loads(link.flags)
+                except TypeError:
+                    linkFlags = link.flags
+
+                if linkFlags.get('cover', False) is True:
+                    OutputManager.putQueue(
+                        {
+                            'url': link.url,
+                            'source': instance.items[0].source,
+                            'identifier': self.work.uuid.hex
+                        },
+                        os.environ['COVER_QUEUE']
+                    )
+
+    def storeEpubs(self, epubsToLoad):
+        for deferredEpub in epubsToLoad:
+            OutputManager.putKinesis(
+                deferredEpub,
+                os.environ['EPUB_STREAM'],
+                recType='item'
+            )
+
+    def setInsertTime(self):
+        super().setInsertTime()

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -88,10 +88,10 @@ class OutputManager():
             queryTime
         ))
         currentTime = datetime.utcnow() - timedelta(days=1)
-        if  (
-                queryTime is not None and
-                datetime.strptime(queryTime.decode('utf-8'), '%Y-%m-%dT%H:%M:%S') >= currentTime
-            ):
+        if (
+            queryTime is not None and
+            datetime.strptime(queryTime.decode('utf-8'), '%Y-%m-%dT%H:%M:%S') >= currentTime
+        ):
             return True
         
         cls.REDIS_CLIENT.set(

--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -77,7 +77,8 @@ def getIdentifiers(session, work):
             .join(Identifier, WORK_IDENTIFIERS, Work)\
             .filter(Work.id == work.id)\
             .all()
-        if len(typeIDs) < 1: continue
+        if len(typeIDs) < 1:
+            continue
         lookupIDs[source] = [i[0] for i in typeIDs]
 
     return lookupIDs
@@ -94,9 +95,12 @@ def getAuthors(agentWorks):
 
     return ', '.join(agents)
 
+
 def createClassifyQuery(classifyQuery, queryType, uuid):
     queryStr = [value for key, value in classifyQuery.items()]
-    if OutputManager.checkRecentQueries('{}'.format('/'.join(queryStr))) is False:
+    if OutputManager.checkRecentQueries(
+        '{}'.format('/'.join(queryStr))
+    ) is False:
         OutputManager.putQueue({
             'type': queryType,
             'uuid': uuid,

--- a/tests/test_accessReport_importer.py
+++ b/tests/test_accessReport_importer.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from lib.importers.accessImporter import AccessReportImporter
+from sfrCore import Item
+
+
+class TestAccessImporter(unittest.TestCase):
+    def test_ImporterInit(self):
+        testImporter = AccessReportImporter({'data': 'data'}, 'session')
+        self.assertEqual(testImporter.data, 'data')
+        self.assertEqual(testImporter.session, 'session')
+
+    def test_getIdentifier(self):
+        testImporter = AccessReportImporter({'data': {}}, 'session')
+        mockItem = MagicMock()
+        mockItem.id = 1
+        testImporter.item = mockItem
+        self.assertEqual(testImporter.identifier, 1)
+
+    @patch.object(AccessReportImporter, 'insertRecord', return_value='testing')
+    def test_lookupRecord(self, mockInsert):
+        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'testing')
+        self.assertEqual(testImporter.item, None)
+        mockInsert.assert_called_once()
+
+    @patch.object(Item, 'addReportData', return_value='testItem')
+    def test_insertRecord_success(self, mockAddData):
+        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testAction = testImporter.insertRecord()
+        self.assertEqual(testAction, 'insert')
+        self.assertEqual(testImporter.item, 'testItem')
+        mockAddData.assert_called_once_with('session', {})
+
+    @patch.object(Item, 'addReportData', return_value=None)
+    def test_insertRecord_failure(self, mockAddData):
+        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testAction = testImporter.insertRecord()
+        self.assertEqual(testAction, 'error')
+        self.assertEqual(testImporter.item, None)
+        mockAddData.assert_called_once_with('session', {})
+
+    @patch('lib.importers.accessImporter.datetime')
+    def test_setInsertTime(self, mockUTC):
+        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testItem = MagicMock()
+        testInstance = MagicMock()
+        testInstance.work = MagicMock()
+        testImporter.item = testItem
+        testItem.instance = testInstance
+        mockUTC.utcnow.return_value = 1000
+        testImporter.setInsertTime()
+        self.assertEqual(testImporter.item.instance.work.date_modified, 1000)

--- a/tests/test_instance_importer.py
+++ b/tests/test_instance_importer.py
@@ -1,0 +1,134 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock, DEFAULT
+
+from lib.importers.instanceImporter import InstanceImporter
+from sfrCore import Instance, Identifier
+from lib.outputManager import OutputManager
+
+
+class TestInstanceImporter(unittest.TestCase):
+    def test_ImporterInit(self):
+        testImporter = InstanceImporter({'data': 'data'}, 'session')
+        self.assertEqual(testImporter.data, 'data')
+        self.assertEqual(testImporter.session, 'session')
+
+    def test_getIdentifier(self):
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        mockInstance = MagicMock()
+        mockInstance.id = 1
+        testImporter.instance = mockInstance
+        self.assertEqual(testImporter.identifier, 1)
+
+    @patch.object(Identifier, 'getByIdentifier', return_value=None)
+    @patch.object(InstanceImporter, 'insertRecord')
+    def test_lookupRecord_success(self, mockInsert, mockLookup):
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'insert')
+        self.assertEqual(testImporter.instance, None)
+        mockLookup.assert_called_once_with(Instance, 'session', [])
+        mockInsert.assert_called_once()
+
+    @patch.dict('os.environ', {'UPDATE_STREAM': 'test'})
+    @patch.object(Identifier, 'getByIdentifier')
+    @patch.object(OutputManager, 'putKinesis')
+    def test_lookupRecord_found(self, mockPut, mockLookup):
+        mockLookup.return_value = 1
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'update')
+        mockLookup.assert_called_once_with(Instance, 'session', [])
+        mockPut.assert_called_once()
+
+    @patch.object(Instance, 'createNew')
+    @patch.multiple(InstanceImporter, storeCovers=DEFAULT, storeEpubs=DEFAULT)
+    def test_insertRecord(self, mockCreate, storeCovers, storeEpubs):
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        mockInstance = MagicMock()
+        mockCreate.return_value = (mockInstance, ['epub1'])
+        testImporter.insertRecord()
+        self.assertEqual(testImporter.instance, mockInstance)
+        storeCovers.assert_called_once()
+        storeEpubs.assert_called_once_with(['epub1'])
+
+    @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
+    @patch.object(OutputManager, 'putQueue')
+    def test_storeCovers_dictFlags(self, mockPut):
+        testImporter = InstanceImporter(
+            {
+                'data': {
+                    'identifiers': [{'identifier': 1}]
+                }
+            },
+            'session'
+        )
+        mockInstance = MagicMock()
+        mockLink = MagicMock()
+        mockInstance.links = [mockLink]
+        mockLink.flags = json.dumps({'cover': True})
+        mockLink.url = 'testing_url'
+        mockItem = MagicMock()
+        mockItem.source = 'testing'
+        mockInstance.items = [mockItem]
+
+        testImporter.instance = mockInstance
+
+        testImporter.storeCovers()
+        mockPut.assert_called_once_with(
+            {
+                'url': 'testing_url',
+                'source': 'testing',
+                'identifier': 1
+            },
+            'test_queue'
+        )
+
+    @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
+    @patch.object(OutputManager, 'putQueue')
+    def test_storeCovers_dictFlags(self, mockPut):
+        testImporter = InstanceImporter(
+            {
+                'data': {
+                    'identifiers': [{'identifier': 1}]
+                }
+            },
+            'session'
+        )
+        mockInstance = MagicMock()
+        mockLink = MagicMock()
+        mockInstance.links = [mockLink]
+        mockLink.flags = {'cover': True}
+        mockLink.url = 'testing_url'
+        mockItem = MagicMock()
+        mockItem.source = 'testing'
+        mockInstance.items = [mockItem]
+
+        testImporter.instance = mockInstance
+
+        testImporter.storeCovers()
+        mockPut.assert_called_once_with(
+            {
+                'url': 'testing_url',
+                'source': 'testing',
+                'identifier': 1
+            },
+            'test_queue'
+        )
+
+    @patch.dict('os.environ', {'EPUB_STREAM': 'test_stream'})
+    @patch.object(OutputManager, 'putKinesis')
+    def test_storeEpubs(self, mockPut):
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        testImporter.storeEpubs(['epub1'])
+        mockPut.assert_called_once_with('epub1', 'test_stream', recType='item')
+
+    @patch('lib.importers.instanceImporter.datetime')
+    def test_setInsertTime(self, mockUTC):
+        testImporter = InstanceImporter({'data': {}}, 'session')
+        testInstance = MagicMock()
+        testInstance.work = MagicMock()
+        testImporter.instance = testInstance
+        mockUTC.utcnow.return_value = 1000
+        testImporter.setInsertTime()
+        self.assertEqual(testImporter.instance.work.date_modified, 1000)

--- a/tests/test_item_importer.py
+++ b/tests/test_item_importer.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from lib.importers.itemImporter import ItemImporter
+from sfrCore import Instance, Identifier, Item
+from lib.outputManager import OutputManager
+
+
+class TestItemImporter(unittest.TestCase):
+    def test_ImporterInit(self):
+        testImporter = ItemImporter({'data': 'data'}, 'session')
+        self.assertEqual(testImporter.data, 'data')
+        self.assertEqual(testImporter.session, 'session')
+
+    def test_getIdentifier(self):
+        testImporter = ItemImporter({'data': {}}, 'session')
+        mockItem = MagicMock()
+        mockItem.id = 1
+        testImporter.item = mockItem
+        self.assertEqual(testImporter.identifier, 1)
+
+    @patch.object(Identifier, 'getByIdentifier', return_value=None)
+    @patch.object(ItemImporter, 'insertRecord')
+    def test_lookupRecord_success(self, mockInsert, mockLookup):
+        testImporter = ItemImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'insert')
+        self.assertEqual(testImporter.item, None)
+        mockLookup.assert_called_once_with(Item, 'session', [])
+        mockInsert.assert_called_once()
+
+    @patch.dict('os.environ', {'UPDATE_STREAM': 'test'})
+    @patch.object(Identifier, 'getByIdentifier')
+    @patch.object(OutputManager, 'putKinesis')
+    def test_lookupRecord_found(self, mockPut, mockLookup):
+        mockLookup.return_value = 1
+        testImporter = ItemImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'update')
+        mockLookup.assert_called_once_with(Item, 'session', [])
+        mockPut.assert_called_once()
+
+    @patch.object(Item, 'createItem')
+    @patch.object(Instance, 'addItemRecord')
+    def test_insertRecord(self, mockAddItem, mockCreate):
+        testImporter = ItemImporter({'data': {}}, 'session')
+        mockCreate.return_value = 'testItem'
+        testImporter.insertRecord()
+        self.assertEqual(testImporter.item, 'testItem')
+        mockAddItem.assert_called_once_with('session', None, 'testItem')
+
+    @patch('lib.importers.itemImporter.datetime')
+    def test_setInsertTime(self, mockUTC):
+        testImporter = ItemImporter({'data': {}}, 'session')
+        testItem = MagicMock()
+        testInstance = MagicMock()
+        testInstance.work = MagicMock()
+        testImporter.item = testItem
+        testItem.instance = testInstance
+        mockUTC.utcnow.return_value = 1000
+        testImporter.setInsertTime()
+        self.assertEqual(testImporter.item.instance.work.date_modified, 1000)

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1,0 +1,136 @@
+from datetime import datetime
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from helpers.errorHelpers import OutputError
+
+os.environ['REDIS_HOST'] = 'redis_url'
+
+from lib.outputManager import OutputManager  # noqa: E402
+
+
+class MockOutputManager(OutputManager):
+    KINESIS_CLIENT = MagicMock()
+    SQS_CLIENT = MagicMock()
+    AWS_REDIS = MagicMock()
+
+
+class MockOutObject:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class OutputTest(unittest.TestCase):
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.get', return_value=None)
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.set')
+    def test_redis_missing(self, mock_set, mock_get):
+        res = MockOutputManager.checkRecentQueries('test/value')
+        self.assertEqual(res, False)
+    
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.get', return_value=(
+        datetime.now().strftime('%Y-%m-%dT%H:%M:%S').encode('utf-8')
+    ))
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.set')
+    def test_redis_current(self, mock_set, mock_get):
+        res = MockOutputManager.checkRecentQueries('test/value')
+        mock_set.assert_not_called()
+        self.assertTrue(res)
+
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.get', return_value=(
+        '2000-01-01T00:00:00'.encode('utf-8')
+    ))
+    @patch('lib.outputManager.OutputManager.REDIS_CLIENT.set')
+    def test_redis_old(self, mock_set, mock_get):
+        res = MockOutputManager.checkRecentQueries('test/value')
+        self.assertEqual(res, False)
+
+    @patch.object(OutputManager, '_convertToJSON', return_value='stream')
+    @patch.object(OutputManager, '_createPartitionKey', return_value=1)
+    def test_putKinesis(self, mockPartition, mockJSON):
+        testManager = MockOutputManager()
+        testManager.putKinesis('data', 'test-stream',
+                               recType='testing')
+        testManager.KINESIS_CLIENT.put_record.assert_called_once_with(
+            StreamName='test-stream',
+            Data='stream',
+            PartitionKey=1
+        )
+
+    @patch.object(OutputManager, '_convertToJSON', return_value='stream')
+    @patch.object(OutputManager, '_createPartitionKey', return_value=1)
+    def test_putKinesis_failure(self, mockPartition, mockJSON):
+        testManager = MockOutputManager()
+        testManager.KINESIS_CLIENT.put_record.side_effect = Exception
+        with self.assertRaises(OutputError):
+            testManager.putKinesis('data', 'test-stream', recType='testing')
+
+    @patch.object(OutputManager, '_convertToJSON', return_value='message')
+    def test_putQueue(self, mockJSON):
+        testManager = MockOutputManager()
+        testManager.putQueue('data', 'test-queue')
+        mockJSON.assert_called_once_with('data')
+        testManager.SQS_CLIENT.send_message.assert_called_once_with(
+            QueueUrl='test-queue',
+            MessageBody='message'
+        )
+
+    @patch.object(OutputManager, '_convertToJSON', return_value='stream')
+    def test_putQueue_failure(self, mockJSON):
+        testManager = MockOutputManager()
+        testManager.SQS_CLIENT.send_message.side_effect = Exception
+        with self.assertRaises(OutputError):
+            testManager.putQueue('data', 'test-queue')
+            mockJSON.assert_called_once_with('data')
+
+    def test_convertToJSON_object(self):
+        testObj = MockOutObject(field1='testing', field2='again')
+
+        jsonStr = MockOutputManager._convertToJSON(testObj)
+        assert jsonStr == '{"field1": "testing", "field2": "again"}'
+
+    @patch('lib.outputManager.json')
+    def test_convertToJSON_failure(self, mockJSON):
+        testDict = {'field': 'something'}
+        mockJSON.dumps.side_effect = [TypeError, '{"field": "something"}']
+        jsonStr = MockOutputManager._convertToJSON(testDict)
+        assert jsonStr == '{"field": "something"}'
+
+    def test_createPartitionKey_primaryIdentifier(self):
+        testObj = {
+            'primary_identifier': {
+                'identifier': 1
+            }
+        }
+
+        testKey = MockOutputManager._createPartitionKey(testObj)
+        self.assertEqual(testKey, '1')
+
+    def test_createPartitionKey_otherIdentifier(self):
+        testObj = {
+            'identifiers': [
+                {
+                    'identifier': 3
+                }, {
+                    'identifier': 1
+                }
+            ]
+        }
+
+        testKey = MockOutputManager._createPartitionKey(testObj)
+        self.assertEqual(testKey, '3')
+
+    def test_createPartitionKey_rowID(self):
+        testObj = {
+            'id': 123
+        }
+
+        testKey = MockOutputManager._createPartitionKey(testObj)
+        self.assertEqual(testKey, '123')
+
+    def test_createPartitionKey_None(self):
+        testObj = {}
+
+        testKey = MockOutputManager._createPartitionKey(testObj)
+        self.assertEqual(testKey, '0')

--- a/tests/test_query_manager.py
+++ b/tests/test_query_manager.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import patch, MagicMock, call, DEFAULT
+
+from lib.outputManager import OutputManager
+from lib.queryManager import (
+    queryWork, getIdentifiers, getAuthors, createClassifyQuery
+)
+
+
+class TestQueryManager(unittest.TestCase):
+    @patch('lib.queryManager.getIdentifiers', return_value=[])
+    @patch('lib.queryManager.getAuthors', return_value='auth1, auth2')
+    @patch('lib.queryManager.createClassifyQuery')
+    def test_queryWork_noIdentifiers(self, mockQuery, mockAuth, mockGet):
+        mockWork = MagicMock()
+        mockWork.title = 'testTitle'
+        mockWork.agent_works = ['auth1', 'auth2']
+        queryWork('session', mockWork, 'testUUID')
+        mockGet.assert_called_once_with('session', mockWork)
+        mockAuth.assert_called_once_with(['auth1', 'auth2'])
+        mockQuery.assert_called_once_with(
+            {'title': 'testTitle', 'authors': 'auth1, auth2'},
+            'authorTitle',
+            'testUUID'
+        )
+
+    @patch('lib.queryManager.getIdentifiers')
+    @patch('lib.queryManager.createClassifyQuery')
+    def test_queryWork_identifiers(self, mockQuery, mockGet):
+        mockGet.return_value = {
+            'testing': [1, 2, 3]
+        }
+        mockWork = MagicMock()
+        queryWork('session', mockWork, 'test')
+        mockGet.assert_called_once_with('session', mockWork)
+        mockQuery.assert_has_calls([
+            call({'idType': 'testing', 'identifier': 1}, 'identifier', 'test'),
+            call({'idType': 'testing', 'identifier': 2}, 'identifier', 'test'),
+            call({'idType': 'testing', 'identifier': 3}, 'identifier', 'test')
+        ])
+
+    def test_getIdentifiers(self):
+        mockSession = MagicMock()
+        mockSession.query().join().filter().all.side_effect = [
+            [],
+            [],
+            [],
+            [(1,), (2,), (3,)],
+            []
+        ]
+        testIdentifiers = getIdentifiers(mockSession, MagicMock())
+        self.assertEqual(testIdentifiers, {'lccn': [1, 2, 3]})
+
+    def test_getAuthors(self):
+        mockRel1 = MagicMock()
+        mockRel1.role = 'author'
+        mockAgent1 = MagicMock()
+        mockAgent1.name = 'agent1'
+        mockRel1.agent = mockAgent1
+
+        mockRel2 = MagicMock()
+        mockRel2.role = 'other'
+        mockAgent2 = MagicMock()
+        mockAgent2.name = 'agent2'
+        mockRel2.agent = mockAgent2
+
+        testAgents = getAuthors([mockRel1, mockRel2])
+        self.assertEqual(testAgents, 'agent1')
+
+    @patch.dict('os.environ', {'CLASSIFY_QUEUE': 'testQueue'})
+    @patch.multiple(OutputManager,
+                    checkRecentQueries=DEFAULT, putQueue=DEFAULT)
+    def test_createClassifyQuery_noCache(self, checkRecentQueries, putQueue):
+        testQuery = {
+            'idType': 'testing',
+            'identifier': '1'
+        }
+        checkRecentQueries.return_value = False
+        createClassifyQuery(testQuery, 'test', 'uuid')
+        checkRecentQueries.assert_called_once_with('testing/1')
+        putQueue.assert_called_once_with(
+            {
+                'type': 'test',
+                'uuid': 'uuid',
+                'fields': testQuery
+            },
+            'testQueue'
+        )
+
+    @patch.dict('os.environ', {'CLASSIFY_QUEUE': 'testQueue'})
+    @patch.multiple(OutputManager,
+                    checkRecentQueries=DEFAULT, putQueue=DEFAULT)
+    def test_createClassifyQuery_cached(self, checkRecentQueries, putQueue):
+        testQuery = {
+            'idType': 'testing',
+            'identifier': '1'
+        }
+        createClassifyQuery(testQuery, 'test', 'uuid')
+        checkRecentQueries.assert_called_once_with('testing/1')
+        putQueue.assert_not_called()

--- a/tests/test_work_importer.py
+++ b/tests/test_work_importer.py
@@ -1,0 +1,148 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock, DEFAULT
+
+from lib.importers.workImporter import WorkImporter
+from sfrCore import Work
+from lib.outputManager import OutputManager
+
+
+class TestWorkImporter(unittest.TestCase):
+    @patch.object(WorkImporter, 'parseData')
+    def test_ImporterInit(self, mockParser):
+        mockParser.return_value = 'data'
+        testImporter = WorkImporter({}, 'session')
+        self.assertEqual(testImporter.data, 'data')
+        self.assertEqual(testImporter.session, 'session')
+
+    def test_WorkParseData_nonNested(self):
+        outData = WorkImporter.parseData({
+            'data': {
+                'field1': 'jerry',
+                'field2': 'hello'
+            }
+        })
+        self.assertEqual(outData, {'field1': 'jerry', 'field2': 'hello'})
+
+    def test_WorkParseData_nested(self):
+        outData = WorkImporter.parseData({
+            'data': {
+                'data': {
+                    'field1': 'jerry',
+                    'field2': 'hello'
+                }
+            }
+        })
+        self.assertEqual(outData, {'field1': 'jerry', 'field2': 'hello'})
+
+    def test_getIdentifier(self):
+        testUpdater = WorkImporter({'data': {}}, 'session')
+        testWork = MagicMock()
+        testUUID = MagicMock()
+        testUUID.hex = 'uuidString'
+        testWork.uuid = testUUID
+        testUpdater.work = testWork
+        self.assertEqual(testUpdater.identifier, 'uuidString')
+
+    @patch.object(Work, 'lookupWork', return_value=None)
+    @patch.object(WorkImporter, 'insertRecord')
+    def test_lookupRecord_success(self, mockInsert, mockLookup):
+        testUpdater = WorkImporter({'data': {}}, 'session')
+        testAction = testUpdater.lookupRecord()
+        self.assertEqual(testAction, 'insert')
+        self.assertEqual(testUpdater.work, None)
+        mockLookup.assert_called_once_with('session', [], None)
+        mockInsert.assert_called_once()
+
+    @patch.dict('os.environ', {'UPDATE_STREAM': 'test'})
+    @patch.object(Work, 'lookupWork')
+    @patch.object(OutputManager, 'putKinesis')
+    def test_lookupRecord_found(self, mockPut, mockLookup):
+        mockWork = MagicMock()
+        mockLookup.return_value = mockWork
+        mockWork.uuid = MagicMock()
+        testImporter = WorkImporter({'data': {}}, 'session')
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'update')
+        mockLookup.assert_called_once_with('session', [], None)
+        mockPut.assert_called_once()
+
+    @patch.multiple(Work, insert=DEFAULT, uuid=DEFAULT)
+    @patch.multiple(WorkImporter, storeCovers=DEFAULT, storeEpubs=DEFAULT)
+    @patch('lib.importers.workImporter.queryWork')
+    def test_insertRecord(self, mockQuery, insert, uuid, storeCovers,
+                          storeEpubs):
+        testImporter = WorkImporter({'data': {}}, 'session')
+        insert.return_value = ['epub1']
+        testImporter.insertRecord()
+        insert.assert_called_once()
+        mockQuery.assert_called_once()
+        storeCovers.assert_called_once()
+        storeEpubs.assert_called_once_with(['epub1'])
+
+    @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
+    @patch.object(OutputManager, 'putQueue')
+    def test_storeCovers_strFlags(self, mockPut):
+        testImporter = WorkImporter({'data': {}}, 'session')
+        mockWork = MagicMock()
+        mockUUID = MagicMock()
+        mockUUID.hex = 'test_uuid'
+        mockWork.uuid = mockUUID
+        mockInstance = MagicMock()
+        mockWork.instances = [mockInstance]
+        mockLink = MagicMock()
+        mockInstance.links = [mockLink]
+        mockLink.flags = json.dumps({'cover': True})
+        mockLink.url = 'testing_url'
+        mockItem = MagicMock()
+        mockItem.source = 'testing'
+        mockInstance.items = [mockItem]
+
+        testImporter.work = mockWork
+
+        testImporter.storeCovers()
+        mockPut.assert_called_once_with(
+            {
+                'url': 'testing_url',
+                'source': 'testing',
+                'identifier': 'test_uuid'
+            },
+            'test_queue'
+        )
+
+    @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
+    @patch.object(OutputManager, 'putQueue')
+    def test_storeCovers_dictFlags(self, mockPut):
+        testImporter = WorkImporter({'data': {}}, 'session')
+        mockWork = MagicMock()
+        mockUUID = MagicMock()
+        mockUUID.hex = 'test_uuid'
+        mockWork.uuid = mockUUID
+        mockInstance = MagicMock()
+        mockWork.instances = [mockInstance]
+        mockLink = MagicMock()
+        mockInstance.links = [mockLink]
+        mockLink.flags = {'cover': True}
+        mockLink.url = 'testing_url'
+        mockItem = MagicMock()
+        mockItem.source = 'testing'
+        mockInstance.items = [mockItem]
+
+        testImporter.work = mockWork
+
+        testImporter.storeCovers()
+        mockPut.assert_called_once_with(
+            {
+                'url': 'testing_url',
+                'source': 'testing',
+                'identifier': 'test_uuid'
+            },
+            'test_queue'
+        )
+
+    @patch.dict('os.environ', {'EPUB_STREAM': 'test_stream'})
+    @patch.object(OutputManager, 'putKinesis')
+    def test_storeEpubs(self, mockPut):
+        testImporter = WorkImporter({'data': {}}, 'session')
+        testImporter.storeEpubs(['epub1'])
+        mockPut.assert_called_once_with('epub1', 'test_stream', recType='item')


### PR DESCRIPTION
This commit updates the database manager function with the same abstract model implementation as the updater function, allowing for cleaner code and enforced regularity in how different record types are implemented.

As part of this, cover parsing methods have been added to the `work` and `instance` record importers. These methods check for the presence of cover links and if found hand them to the cover processing queue for storage in s3. This allows the ingest pipeline to take covers from the data harvesters and add them to the database.

This commit also extends the test coverage for this function, both for the new importer structure and some existing methods that were previously missing