### PR TITLE
HOTFIX source data

### DIFF
--- a/lib/importers/instanceImporter.py
+++ b/lib/importers/instanceImporter.py
@@ -9,6 +9,7 @@ from lib.outputManager import OutputManager
 
 class InstanceImporter(AbstractImporter):
     def __init__(self, record, session):
+        self.source = record.get('source', 'unknown')
         self.data = record['data']
         self.instance = None
         super().__init__(record, session)
@@ -65,7 +66,7 @@ class InstanceImporter(AbstractImporter):
                 OutputManager.putQueue(
                     {
                         'url': link.url,
-                        'source': self.instance.items[0].source,
+                        'source': self.source,
                         'identifier': self.data['identifiers'][0]['identifier']
                     },
                     os.environ['COVER_QUEUE']

--- a/lib/importers/workImporter.py
+++ b/lib/importers/workImporter.py
@@ -9,6 +9,7 @@ from lib.outputManager import OutputManager
 
 class WorkImporter(AbstractImporter):
     def __init__(self, record, session):
+        self.source = record.get('source', 'unknown')
         self.data = WorkImporter.parseData(record)
         self.work = None
         super().__init__(record, session)
@@ -70,7 +71,7 @@ class WorkImporter(AbstractImporter):
                     OutputManager.putQueue(
                         {
                             'url': link.url,
-                            'source': instance.items[0].source,
+                            'source': self.source,
                             'identifier': self.work.uuid.hex
                         },
                         os.environ['COVER_QUEUE']

--- a/tests/test_instance_importer.py
+++ b/tests/test_instance_importer.py
@@ -91,7 +91,8 @@ class TestInstanceImporter(unittest.TestCase):
             {
                 'data': {
                     'identifiers': [{'identifier': 1}]
-                }
+                },
+                'source': 'testing'
             },
             'session'
         )
@@ -100,9 +101,6 @@ class TestInstanceImporter(unittest.TestCase):
         mockInstance.links = [mockLink]
         mockLink.flags = {'cover': True}
         mockLink.url = 'testing_url'
-        mockItem = MagicMock()
-        mockItem.source = 'testing'
-        mockInstance.items = [mockItem]
 
         testImporter.instance = mockInstance
 

--- a/tests/test_work_importer.py
+++ b/tests/test_work_importer.py
@@ -83,7 +83,7 @@ class TestWorkImporter(unittest.TestCase):
     @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
     @patch.object(OutputManager, 'putQueue')
     def test_storeCovers_strFlags(self, mockPut):
-        testImporter = WorkImporter({'data': {}}, 'session')
+        testImporter = WorkImporter({'data': {}, 'source': 'test'}, 'session')
         mockWork = MagicMock()
         mockUUID = MagicMock()
         mockUUID.hex = 'test_uuid'
@@ -94,9 +94,6 @@ class TestWorkImporter(unittest.TestCase):
         mockInstance.links = [mockLink]
         mockLink.flags = json.dumps({'cover': True})
         mockLink.url = 'testing_url'
-        mockItem = MagicMock()
-        mockItem.source = 'testing'
-        mockInstance.items = [mockItem]
 
         testImporter.work = mockWork
 
@@ -104,7 +101,7 @@ class TestWorkImporter(unittest.TestCase):
         mockPut.assert_called_once_with(
             {
                 'url': 'testing_url',
-                'source': 'testing',
+                'source': 'test',
                 'identifier': 'test_uuid'
             },
             'test_queue'
@@ -113,7 +110,7 @@ class TestWorkImporter(unittest.TestCase):
     @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
     @patch.object(OutputManager, 'putQueue')
     def test_storeCovers_dictFlags(self, mockPut):
-        testImporter = WorkImporter({'data': {}}, 'session')
+        testImporter = WorkImporter({'data': {}, 'source': 'test'}, 'session')
         mockWork = MagicMock()
         mockUUID = MagicMock()
         mockUUID.hex = 'test_uuid'
@@ -124,9 +121,6 @@ class TestWorkImporter(unittest.TestCase):
         mockInstance.links = [mockLink]
         mockLink.flags = {'cover': True}
         mockLink.url = 'testing_url'
-        mockItem = MagicMock()
-        mockItem.source = 'testing'
-        mockInstance.items = [mockItem]
 
         testImporter.work = mockWork
 
@@ -134,7 +128,7 @@ class TestWorkImporter(unittest.TestCase):
         mockPut.assert_called_once_with(
             {
                 'url': 'testing_url',
-                'source': 'testing',
+                'source': 'test',
                 'identifier': 'test_uuid'
             },
             'test_queue'


### PR DESCRIPTION
The manager previously attempted to find the source from a child record of the record being imported, ultimately from an `item` record. However, that `source` field is difficult to access, and an easier place to locate it is in the record passed from the Kinesis stream to the function. This includes a `source` value in an easily retrievable location and allows the source to be accurately set for the cover parser, which is currently the only aspect of the function which utilizes that value