### PR TITLE
SFR-683 Add cover importer to db-manager

### DIFF
--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -2,6 +2,7 @@ from lib.importers.workImporter import WorkImporter
 from lib.importers.instanceImporter import InstanceImporter
 from lib.importers.itemImporter import ItemImporter
 from lib.importers.accessImporter import AccessReportImporter
+from lib.importers.coverImporter import CoverImporter
 
 from helpers.logHelpers import createLog
 
@@ -13,6 +14,7 @@ importers = {
     'instance': InstanceImporter,
     'item': ItemImporter,
     'access_report': AccessReportImporter,
+    'cover': CoverImporter
 }
 
 

--- a/lib/importers/coverImporter.py
+++ b/lib/importers/coverImporter.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+import os
+from sfrCore import Link, Instance
+
+from lib.importers.abstractImporter import AbstractImporter
+from lib.outputManager import OutputManager
+
+
+class CoverImporter(AbstractImporter):
+    def __init__(self, record, session):
+        self.data = record['data']
+        self.link = None
+        super().__init__(record, session)
+
+    @property
+    def identifier(self):
+        return self.link.id
+
+    def lookupRecord(self):
+        self.logger.info('Ingesting cover record')
+        instanceID = self.data.pop('instanceID', None)
+        uri = self.data.pop('uri', None)
+
+        coverLink = self.session.query(Link)\
+            .join(Link.instances)\
+            .filter(Instance.id == instanceID)\
+            .filter(Link.url == uri)\
+            .one_or_none()
+
+        if coverLink is not None:
+            return 'existing'
+
+        self.logger.info('Ingesting cover link record at {}'.format(uri))
+
+        self.insertRecord(instanceID, uri)
+        return 'insert'
+
+    def insertRecord(self, instanceID, uri):
+        instance = self.session.query(Instance).get(instanceID)
+
+        self.link = Link(
+            url=uri,
+            flags={'cover': True, 'temporary': True}
+        )
+
+        self.logger.debug('Got cover link, adding to instance')
+        instance.links.add(self.link)
+        self.session.add(instance)
+
+        OutputManager.putQueue(
+            {
+                'url': uri,
+                'source': self.data.get('source', 'unknown'),
+                'identifier': instanceID
+            },
+            os.environ['COVER_QUEUE']
+        )
+
+    def setInsertTime(self):
+        self.link.instances[0].work.date_modified = datetime.utcnow()

--- a/tests/test_cover_importer.py
+++ b/tests/test_cover_importer.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from lib.importers.coverImporter import CoverImporter
+from lib.outputManager import OutputManager
+
+
+class TestCoverImporter(unittest.TestCase):
+    def test_ImporterInit(self):
+        testImporter = CoverImporter({'data': 'data'}, 'session')
+        self.assertEqual(testImporter.data, 'data')
+        self.assertEqual(testImporter.session, 'session')
+
+    def test_getIdentifier(self):
+        testImporter = CoverImporter({'data': {}}, 'session')
+        mockLink = MagicMock()
+        mockLink.id = 1
+        testImporter.link = mockLink
+        self.assertEqual(testImporter.identifier, 1)
+
+    @patch.object(CoverImporter, 'insertRecord')
+    def test_lookupRecord_success(self, mockInsert):
+        mockSession = MagicMock()
+        testImporter = CoverImporter({'data': {}}, mockSession)
+        mockSession.query().join().filter().filter().one_or_none\
+            .return_value = None
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'insert')
+        mockInsert.assert_called_once()
+
+    def test_lookupRecord_found(self):
+        testImporter = CoverImporter({'data': {}}, MagicMock())
+        testAction = testImporter.lookupRecord()
+        self.assertEqual(testAction, 'existing')
+
+    @patch.dict('os.environ', {'COVER_QUEUE': 'testQueue'})
+    @patch('lib.importers.coverImporter.Link', return_value='testLink')
+    @patch.object(OutputManager, 'putQueue')
+    def test_insertRecord(self, mockPut, mockLink):
+        mockSession = MagicMock()
+        mockInstance = MagicMock()
+        mockInstance.links = set()
+        mockSession.query().get.return_value = mockInstance
+
+        testImporter = CoverImporter({'data': {}}, mockSession)
+        testImporter.insertRecord(1, 'testURI')
+
+        self.assertEqual(testImporter.link, 'testLink')
+        self.assertEqual(len(list(mockInstance.links)), 1)
+
+    @patch('lib.importers.coverImporter.datetime')
+    def test_setInsertTime(self, mockUTC):
+        testImporter = CoverImporter({'data': {}}, 'session')
+        testLink = MagicMock()
+        testInstance = MagicMock()
+        testInstance.work = MagicMock()
+        testImporter.link = testLink
+        testLink.instances = [testInstance]
+        mockUTC.utcnow.return_value = 1000
+        testImporter.setInsertTime()
+        self.assertEqual(
+            testImporter.link.instances[0].work.date_modified,
+            1000
+        )


### PR DESCRIPTION
This adds a new class for importing cover objects for instance records from the cover lookup service. These are distinct from the covers that come from the data sources in that they can be associated with any instance that does not already have a cover. The objects are stored in the database as `Link` records and associated with the correct `Instance` record before being passed to the `sfr-s3-cover` function where local, permament copies are created in s3, which are then used to replace these temporary links