### PR TITLE
SFR-683 add media types

### DIFF
--- a/lib/importers/coverImporter.py
+++ b/lib/importers/coverImporter.py
@@ -40,6 +40,7 @@ class CoverImporter(AbstractImporter):
 
         self.link = Link(
             url=uri,
+            media_type=self.data.get('mediaType', None),
             flags={'cover': True, 'temporary': True}
         )
 

--- a/tests/test_cover_importer.py
+++ b/tests/test_cover_importer.py
@@ -34,18 +34,18 @@ class TestCoverImporter(unittest.TestCase):
         self.assertEqual(testAction, 'existing')
 
     @patch.dict('os.environ', {'COVER_QUEUE': 'testQueue'})
-    @patch('lib.importers.coverImporter.Link', return_value='testLink')
     @patch.object(OutputManager, 'putQueue')
-    def test_insertRecord(self, mockPut, mockLink):
+    def test_insertRecord(self, mockPut):
         mockSession = MagicMock()
         mockInstance = MagicMock()
         mockInstance.links = set()
         mockSession.query().get.return_value = mockInstance
 
         testImporter = CoverImporter({'data': {}}, mockSession)
-        testImporter.insertRecord(1, 'testURI')
+        testImporter.insertRecord(1, 'testURI.jpg')
 
-        self.assertEqual(testImporter.link, 'testLink')
+        self.assertEqual(testImporter.link.url, 'testuri.jpg')
+        self.assertEqual(testImporter.link.media_type, 'image/jpeg')
         self.assertEqual(len(list(mockInstance.links)), 1)
 
     @patch('lib.importers.coverImporter.datetime')

--- a/tests/test_cover_importer.py
+++ b/tests/test_cover_importer.py
@@ -41,7 +41,10 @@ class TestCoverImporter(unittest.TestCase):
         mockInstance.links = set()
         mockSession.query().get.return_value = mockInstance
 
-        testImporter = CoverImporter({'data': {}}, mockSession)
+        testImporter = CoverImporter(
+            {'data': {'mediaType': 'image/jpeg'}},
+            mockSession
+        )
         testImporter.insertRecord(1, 'testURI.jpg')
 
         self.assertEqual(testImporter.link.url, 'testuri.jpg')


### PR DESCRIPTION
This adds a check for a media type attached to any incoming cover record. It is assumed for now that these will be standard MIMETYPE strings, though it may be desirable to implement some type of validation or checking of this in the near future. At the moment nothing relies on this data so it is safe to trust the sources that we have (which are all internal and validated by us at an earlier step in any case)