### PR TITLE
SFR-706 Fix Multi Item Imports

### DIFF
--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -35,6 +35,12 @@ class ItemImporter(AbstractImporter):
                 'identifier': itemID,
                 'weight': 1
             }
+
+            # Remove the instance_id so it is nor parsed by the db layer
+            self.data.pop('instance_id', None)
+
+            self.item = self.session.query(Item).get(itemID)
+
             OutputManager.putKinesis(
                 self.data,
                 os.environ['UPDATE_STREAM'],

--- a/scripts/lambdaRun.py
+++ b/scripts/lambdaRun.py
@@ -43,7 +43,7 @@ def main():
 
     elif re.match(r'^run-local', runType):
         logger.info('Running test locally with development environment')
-        env = 'development'
+        env = 'local'
         setEnvVars(env)
         subprocess.run([
             'lambda',

--- a/tests/test_item_importer.py
+++ b/tests/test_item_importer.py
@@ -34,10 +34,12 @@ class TestItemImporter(unittest.TestCase):
     @patch.object(OutputManager, 'putKinesis')
     def test_lookupRecord_found(self, mockPut, mockLookup):
         mockLookup.return_value = 1
-        testImporter = ItemImporter({'data': {}}, 'session')
+        mockSession = MagicMock()
+        testImporter = ItemImporter({'data': {}}, mockSession)
         testAction = testImporter.lookupRecord()
         self.assertEqual(testAction, 'update')
-        mockLookup.assert_called_once_with(Item, 'session', [])
+        mockLookup.assert_called_once_with(Item, mockSession, [])
+        mockSession.query().get.assert_called_once_with(1)
         mockPut.assert_called_once()
 
     @patch.object(Item, 'createItem')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -32,7 +32,7 @@ class TestScripts(unittest.TestCase):
     @patch('os.remove')
     def test_run_local(self, mock_rm, mock_run, mock_envVars):
         main()
-        mock_envVars.assert_called_once_with('development')
+        mock_envVars.assert_called_once_with('local')
         mock_run.assert_called_once()
         mock_rm.assert_called_once_with('run_config.yaml')
 


### PR DESCRIPTION
The item importer had two different errors, both affecting the case when the importer receives a record that should be passed to the updater. First, the local reference to the SQLAlchemy `Item` record was not being properly created, and a simple query was added to create this reference. While this caused an error, this does not actually have any side-effects. Second, and more critically, the `instance_id` was being left attached to the item record, which caused the `Item` model to crash as it is not expecting this field. This is removed when inserting an item, so it is simply removed in the same way.