### PR TITLE
HOTFIX Add Accessibility Reports

### DIFF
--- a/lib/importers/accessImporter.py
+++ b/lib/importers/accessImporter.py
@@ -20,11 +20,12 @@ class AccessReportImporter(AbstractImporter):
         return self.insertRecord()
 
     def insertRecord(self):
-        self.item = Item.addReportData(self.session, self.data)
+        accessReport = Item.addReportData(self.session, self.data)
 
-        if not self.item:
+        if not accessReport:
             return 'error'
 
+        self.item = accessReport.item
         return 'insert'
 
     def setInsertTime(self):

--- a/tests/test_accessReport_importer.py
+++ b/tests/test_accessReport_importer.py
@@ -26,8 +26,11 @@ class TestAccessImporter(unittest.TestCase):
         self.assertEqual(testImporter.item, None)
         mockInsert.assert_called_once()
 
-    @patch.object(Item, 'addReportData', return_value='testItem')
+    @patch.object(Item, 'addReportData')
     def test_insertRecord_success(self, mockAddData):
+        mockReport = MagicMock()
+        mockReport.item = 'testItem'
+        mockAddData.return_value = mockReport
         testImporter = AccessReportImporter({'data': {}}, 'session')
         testAction = testImporter.insertRecord()
         self.assertEqual(testAction, 'insert')


### PR DESCRIPTION
The accessibility report importer was not accessing or storing the parent item record for these reports. This checks for a valid item before returning