### PR TITLE
SFR-703 Performance Improvements

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -10,6 +10,7 @@ environment_variables:
     DB_USER: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQEkoQNYODSk+m8cJJethF9fAAAAYTBfBgkqhkiG9w0BBwagUjBQAgEAMEsGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMRn26MsM9MH+2cXAyAgEQgB7gWCou8rWbTzfnj2dpcXupJEiP4FcYNo9x0b5Au44=
     DB_PSWD: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQF9q6qZdlshh6jj9SCwRnrxAAAAaTBnBgkqhkiG9w0BBwagWjBYAgEAMFMGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3VcD1csTm05LRnTxAgEQgCaaffMztl8n0z5ic66yft0nGxzX8141R/Y987kqXEeQYemN4DJ2zg==
 
+    INGEST_STREAM: sfr-db-ingest-development
     UPDATE_STREAM: sfr-db-update-development
     EPUB_STREAM: sfr-epub-ingest-development
     CLASSIFY_QUEUE: https://sqs.us-east-1.amazonaws.com/224280085904/sfr-oclc-classify-development

--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -1,34 +1,55 @@
+from collections import defaultdict
+
 from lib.importers.workImporter import WorkImporter
 from lib.importers.instanceImporter import InstanceImporter
 from lib.importers.itemImporter import ItemImporter
 from lib.importers.accessImporter import AccessReportImporter
 from lib.importers.coverImporter import CoverImporter
+from lib.outputManager import OutputManager
 
 from helpers.logHelpers import createLog
 
 logger = createLog('db_manager')
 
-# Load Updaters for specific types of records, all based on AbstractUpdater
-importers = {
-    'work': WorkImporter,
-    'instance': InstanceImporter,
-    'item': ItemImporter,
-    'access_report': AccessReportImporter,
-    'cover': CoverImporter
-}
 
+class DBManager:
+    # Load Updaters for specific types of records, all based on AbstractUpdater
+    IMPORTERS = {
+        'work': WorkImporter,
+        'instance': InstanceImporter,
+        'item': ItemImporter,
+        'access_report': AccessReportImporter,
+        'cover': CoverImporter
+    }
 
-def importRecord(session, record):
-    recordType = record.get('type', 'work')
-    logger.info('Updating {} record'.format(recordType))
+    def __init__(self, session):
+        self.session = session
+        self.logger = logger
+        self.kinesisMsgs = defaultdict(list)
+        self.sqsMsgs = defaultdict(list)
 
-    # Create specific importer
-    importer = importers[recordType](record, session)
-    action = importer.lookupRecord()
-    if action == 'insert':
-        importer.setInsertTime()
+    def importRecord(self, record):
+        recordType = record.get('type', 'work')
+        logger.info('Updating {} record'.format(recordType))
 
-    logger.info('{} {} #{}'.format(
-        action, recordType.upper(), importer.identifier
-    ))
-    return '{} {} #{}'.format(action, recordType.upper(), importer.identifier)
+        # Create specific importer
+        importer = self.IMPORTERS[recordType](
+            record, self.session, self.kinesisMsgs, self.sqsMsgs
+        )
+        action = importer.lookupRecord()
+        if action == 'insert':
+            importer.setInsertTime()
+
+        self.logger.info('{} {} #{}'.format(
+            action, recordType.upper(), importer.identifier
+        ))
+        return '{} {} #{}'.format(
+            action, recordType.upper(), importer.identifier
+        )
+
+    def sendMessages(self):
+        for stream, records in self.kinesisMsgs.items():
+            OutputManager.putKinesisBatch(stream, records)
+
+        for queue, messages in self.sqsMsgs.items():
+            OutputManager.putQueueBatches(queue, messages)

--- a/lib/importers/abstractImporter.py
+++ b/lib/importers/abstractImporter.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod, abstractproperty
 
-from helpers.logHelpers import createLog
-
 
 class AbstractImporter(ABC):
     @abstractmethod
@@ -26,4 +24,4 @@ class AbstractImporter(ABC):
         pass
 
     def createLogger(self):
-        return createLog(type(self).__name__)
+        pass

--- a/lib/importers/accessImporter.py
+++ b/lib/importers/accessImporter.py
@@ -2,12 +2,16 @@ from datetime import datetime
 from sfrCore import Item
 
 from lib.importers.abstractImporter import AbstractImporter
+from helpers.logHelpers import createLog
+
+logger = createLog('accessImporter')
 
 
 class AccessReportImporter(AbstractImporter):
     def __init__(self, record, session):
         self.data = record['data']
         self.item = None
+        self.logger = self.createLogger()
         super().__init__(record, session)
 
     @property
@@ -30,3 +34,6 @@ class AccessReportImporter(AbstractImporter):
 
     def setInsertTime(self):
         self.item.instance.work.date_modified = datetime.utcnow()
+
+    def createLogger(self):
+        return logger

--- a/lib/importers/accessImporter.py
+++ b/lib/importers/accessImporter.py
@@ -8,7 +8,7 @@ logger = createLog('accessImporter')
 
 
 class AccessReportImporter(AbstractImporter):
-    def __init__(self, record, session):
+    def __init__(self, record, session, kinesisMsgs, sqsMsgs):
         self.data = record['data']
         self.item = None
         self.logger = self.createLogger()

--- a/lib/importers/coverImporter.py
+++ b/lib/importers/coverImporter.py
@@ -9,7 +9,7 @@ logger = createLog('coverImporter')
 
 
 class CoverImporter(AbstractImporter):
-    def __init__(self, record, session):
+    def __init__(self, record, session, kinesisMsgs, sqsMsgs):
         self.data = record['data']
         self.link = None
         self.kinesisMsgs = kinesisMsgs
@@ -53,14 +53,11 @@ class CoverImporter(AbstractImporter):
         instance.links.add(self.link)
         self.session.add(instance)
 
-        OutputManager.putQueue(
-            {
-                'url': uri,
-                'source': self.data.get('source', 'unknown'),
-                'identifier': instanceID
-            },
-            os.environ['COVER_QUEUE']
-        )
+        self.sqsMsgs[os.environ['COVER_QUEUE']].append({
+            'url': uri,
+            'source': self.data.get('source', 'unknown'),
+            'identifier': instanceID
+        })
 
     def setInsertTime(self):
         self.link.instances[0].work.date_modified = datetime.utcnow()

--- a/lib/importers/coverImporter.py
+++ b/lib/importers/coverImporter.py
@@ -3,13 +3,18 @@ import os
 from sfrCore import Link, Instance
 
 from lib.importers.abstractImporter import AbstractImporter
-from lib.outputManager import OutputManager
+from helpers.logHelpers import createLog
+
+logger = createLog('coverImporter')
 
 
 class CoverImporter(AbstractImporter):
     def __init__(self, record, session):
         self.data = record['data']
         self.link = None
+        self.kinesisMsgs = kinesisMsgs
+        self.sqsMsgs = sqsMsgs
+        self.logger = self.createLogger()
         super().__init__(record, session)
 
     @property
@@ -59,3 +64,6 @@ class CoverImporter(AbstractImporter):
 
     def setInsertTime(self):
         self.link.instances[0].work.date_modified = datetime.utcnow()
+
+    def createLogger(self):
+        return logger

--- a/lib/importers/instanceImporter.py
+++ b/lib/importers/instanceImporter.py
@@ -4,7 +4,9 @@ import os
 from sfrCore import Instance, Identifier
 
 from lib.importers.abstractImporter import AbstractImporter
-from lib.outputManager import OutputManager
+from helpers.logHelpers import createLog
+
+logger = createLog('instanceImporter')
 
 
 class InstanceImporter(AbstractImporter):
@@ -12,6 +14,9 @@ class InstanceImporter(AbstractImporter):
         self.source = record.get('source', 'unknown')
         self.data = record['data']
         self.instance = None
+        self.kinesisMsgs = kinesisMsgs
+        self.sqsMsgs = sqsMsgs
+        self.logger = self.createLogger()
         super().__init__(record, session)
 
     @property
@@ -82,3 +87,6 @@ class InstanceImporter(AbstractImporter):
 
     def setInsertTime(self):
         self.instance.work.date_modified = datetime.utcnow()
+
+    def createLogger(self):
+        return logger

--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -3,13 +3,18 @@ import os
 from sfrCore import Item, Instance, Identifier
 
 from lib.importers.abstractImporter import AbstractImporter
-from lib.outputManager import OutputManager
+from helpers.logHelpers import createLog
+
+logger = createLog('itemImporter')
 
 
 class ItemImporter(AbstractImporter):
     def __init__(self, record, session):
         self.data = record['data']
         self.item = None
+        self.kinesisMsgs = kinesisMsgs
+        self.sqsMsgs = sqsMsgs
+        self.logger = self.createLogger()
         super().__init__(record, session)
 
     @property
@@ -63,3 +68,6 @@ class ItemImporter(AbstractImporter):
 
     def setInsertTime(self):
         self.item.instance.work.date_modified = datetime.utcnow()
+
+    def createLogger(self):
+        return logger

--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -9,7 +9,7 @@ logger = createLog('itemImporter')
 
 
 class ItemImporter(AbstractImporter):
-    def __init__(self, record, session):
+    def __init__(self, record, session, kinesisMsgs, sqsMsgs):
         self.data = record['data']
         self.item = None
         self.kinesisMsgs = kinesisMsgs
@@ -46,11 +46,10 @@ class ItemImporter(AbstractImporter):
 
             self.item = self.session.query(Item).get(itemID)
 
-            OutputManager.putKinesis(
-                self.data,
-                os.environ['UPDATE_STREAM'],
-                recType='item'
-            )
+            self.kinesisMsgs[os.environ['UPDATE_STREAM']].append({
+                'recType': 'item',
+                'data': self.data
+            })
             return 'update'
 
         self.logger.info('Ingesting item record')

--- a/lib/importers/workImporter.py
+++ b/lib/importers/workImporter.py
@@ -4,7 +4,9 @@ from sfrCore import Work
 
 from lib.importers.abstractImporter import AbstractImporter
 from lib.queryManager import queryWork
-from lib.outputManager import OutputManager
+from helpers.logHelpers import createLog
+
+logger = createLog('workImporter')
 
 
 class WorkImporter(AbstractImporter):
@@ -12,6 +14,9 @@ class WorkImporter(AbstractImporter):
         self.source = record.get('source', 'unknown')
         self.data = WorkImporter.parseData(record)
         self.work = None
+        self.kinesisMsgs = kinesisMsgs
+        self.sqsMsgs = sqsMsgs
+        self.logger = self.createLogger()
         super().__init__(record, session)
 
     @staticmethod
@@ -87,3 +92,6 @@ class WorkImporter(AbstractImporter):
 
     def setInsertTime(self):
         super().setInsertTime()
+
+    def createLogger(self):
+        return logger

--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -61,6 +61,28 @@ class OutputManager():
             raise OutputError('Failed to write result to output stream!')
 
     @classmethod
+    def putKinesisBatch(cls, records, stream):
+        streamRecords = [
+            {
+                'Data': OutputManager._convertToJSON(
+                    {'status': 200, 'data': r['data'], 'type': r['recType']}
+                ),
+                'PartitionKey': OutputManager._createPartitionKey(r['data'])
+            }
+            for r in records
+        ]
+
+        try:
+            cls.KINESIS_CLIENT.put_records(
+                Records=streamRecords,
+                StreamName=stream
+            )
+        except Exception as err:
+            logger.error('Kinesis Batch write error')
+            logger.debug(err)
+            raise OutputError('Failed to write batch to Kinesis')
+
+    @classmethod
     def putQueue(cls, data, outQueue):
         """This puts record identifiers into an SQS queue that is read for
         records to (re)index in ElasticSearch. Takes an object which is
@@ -79,7 +101,32 @@ class OutputManager():
         except:
             logger.error('SQS Write error!')
             raise OutputError('Failed to write result to output stream!')
-    
+
+    @classmethod
+    def putQueueBatches(cls, messages, outQueue):
+        while len(messages) > 0:
+            jsonMessages = []
+            for i in range(10):
+                try:
+                    jsonMessages.append({
+                        'MessageBody': OutputManager._convertToJSON(
+                            messages.pop()
+                        ),
+                        'Id': i
+                    })
+                except IndexError:
+                    break
+
+            try:
+                cls.SQS_CLIENT.send_message_batch(
+                    QueueUrl=outQueue,
+                    Entries=jsonMessages
+                )
+            except Exception as err:
+                logger.error('Failed to write messages to queue')
+                logger.debug(err)
+                raise OutputError('Failed to write results to queue')
+
     @classmethod
     def checkRecentQueries(cls, queryString):
         queryTime = cls.REDIS_CLIENT.get(queryString)

--- a/service.py
+++ b/service.py
@@ -112,7 +112,7 @@ def parseRecord(encodedRec, manager):
         logger.debug(opErr)
         OutputManager.putKinesis(
             record.get('data'),
-            os.environ['UPDATE_STREAM'],
+            os.environ['INGEST_STREAM'],
             recType=record.get('type', 'work'),
         )
     except Exception as err:  # noqa: Q000

--- a/tests/test_accessReport_importer.py
+++ b/tests/test_accessReport_importer.py
@@ -7,12 +7,12 @@ from sfrCore import Item
 
 class TestAccessImporter(unittest.TestCase):
     def test_ImporterInit(self):
-        testImporter = AccessReportImporter({'data': 'data'}, 'session')
+        testImporter = AccessReportImporter({'data': 'data'}, 'session', {}, {})
         self.assertEqual(testImporter.data, 'data')
         self.assertEqual(testImporter.session, 'session')
 
     def test_getIdentifier(self):
-        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
         mockItem = MagicMock()
         mockItem.id = 1
         testImporter.item = mockItem
@@ -20,7 +20,7 @@ class TestAccessImporter(unittest.TestCase):
 
     @patch.object(AccessReportImporter, 'insertRecord', return_value='testing')
     def test_lookupRecord(self, mockInsert):
-        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
         testAction = testImporter.lookupRecord()
         self.assertEqual(testAction, 'testing')
         self.assertEqual(testImporter.item, None)
@@ -31,7 +31,7 @@ class TestAccessImporter(unittest.TestCase):
         mockReport = MagicMock()
         mockReport.item = 'testItem'
         mockAddData.return_value = mockReport
-        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
         testAction = testImporter.insertRecord()
         self.assertEqual(testAction, 'insert')
         self.assertEqual(testImporter.item, 'testItem')
@@ -39,7 +39,7 @@ class TestAccessImporter(unittest.TestCase):
 
     @patch.object(Item, 'addReportData', return_value=None)
     def test_insertRecord_failure(self, mockAddData):
-        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
         testAction = testImporter.insertRecord()
         self.assertEqual(testAction, 'error')
         self.assertEqual(testImporter.item, None)
@@ -47,7 +47,7 @@ class TestAccessImporter(unittest.TestCase):
 
     @patch('lib.importers.accessImporter.datetime')
     def test_setInsertTime(self, mockUTC):
-        testImporter = AccessReportImporter({'data': {}}, 'session')
+        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
         testItem = MagicMock()
         testInstance = MagicMock()
         testInstance.work = MagicMock()

--- a/tests/test_cover_importer.py
+++ b/tests/test_cover_importer.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -7,12 +8,12 @@ from lib.outputManager import OutputManager
 
 class TestCoverImporter(unittest.TestCase):
     def test_ImporterInit(self):
-        testImporter = CoverImporter({'data': 'data'}, 'session')
+        testImporter = CoverImporter({'data': 'data'}, 'session', {}, {})
         self.assertEqual(testImporter.data, 'data')
         self.assertEqual(testImporter.session, 'session')
 
     def test_getIdentifier(self):
-        testImporter = CoverImporter({'data': {}}, 'session')
+        testImporter = CoverImporter({'data': {}}, 'session', {}, {})
         mockLink = MagicMock()
         mockLink.id = 1
         testImporter.link = mockLink
@@ -21,7 +22,7 @@ class TestCoverImporter(unittest.TestCase):
     @patch.object(CoverImporter, 'insertRecord')
     def test_lookupRecord_success(self, mockInsert):
         mockSession = MagicMock()
-        testImporter = CoverImporter({'data': {}}, mockSession)
+        testImporter = CoverImporter({'data': {}}, mockSession, {}, {})
         mockSession.query().join().filter().filter().one_or_none\
             .return_value = None
         testAction = testImporter.lookupRecord()
@@ -29,13 +30,12 @@ class TestCoverImporter(unittest.TestCase):
         mockInsert.assert_called_once()
 
     def test_lookupRecord_found(self):
-        testImporter = CoverImporter({'data': {}}, MagicMock())
+        testImporter = CoverImporter({'data': {}}, MagicMock(), {}, {})
         testAction = testImporter.lookupRecord()
         self.assertEqual(testAction, 'existing')
 
     @patch.dict('os.environ', {'COVER_QUEUE': 'testQueue'})
-    @patch.object(OutputManager, 'putQueue')
-    def test_insertRecord(self, mockPut):
+    def test_insertRecord(self):
         mockSession = MagicMock()
         mockInstance = MagicMock()
         mockInstance.links = set()
@@ -43,17 +43,19 @@ class TestCoverImporter(unittest.TestCase):
 
         testImporter = CoverImporter(
             {'data': {'mediaType': 'image/jpeg'}},
-            mockSession
+            mockSession,
+            defaultdict(list), defaultdict(list)
         )
         testImporter.insertRecord(1, 'testURI.jpg')
 
         self.assertEqual(testImporter.link.url, 'testuri.jpg')
         self.assertEqual(testImporter.link.media_type, 'image/jpeg')
+        self.assertEqual(len(testImporter.sqsMsgs['testQueue']), 1)
         self.assertEqual(len(list(mockInstance.links)), 1)
 
     @patch('lib.importers.coverImporter.datetime')
     def test_setInsertTime(self, mockUTC):
-        testImporter = CoverImporter({'data': {}}, 'session')
+        testImporter = CoverImporter({'data': {}}, 'session', {}, {})
         testLink = MagicMock()
         testInstance = MagicMock()
         testInstance.work = MagicMock()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -69,14 +69,15 @@ class TestHandler(unittest.TestCase):
         res = parseRecords([1, 2, 3])
         self.assertRaises(DBError)
     
-    @patch('service.importRecord', return_value=True)
+    @patch('service.DBManager')
     @patch('service.SessionManager')
-    def test_record_parse_success(self, mock_import, mock_manager):
+    def test_record_parse_success(self, mockManager, mockSession):
         testRec = base64.b64encode(json.dumps({
             'status': 200,
             'data': 'data'
         }).encode('utf-8'))
-        self.assertTrue(parseRecord({'kinesis': {'data': testRec}}, 'session'))
+        mockManager.importRecord.return_value = True
+        self.assertTrue(parseRecord({'kinesis': {'data': testRec}}, mockManager))
     
     def test_record_parse_none(self):
         testRec = base64.b64encode(json.dumps({
@@ -112,15 +113,16 @@ class TestHandler(unittest.TestCase):
         }).encode('utf-8'))
         with self.assertRaises(DataError):
             parseRecord({'kinesis': {'data': testRec}}, 'session')
-        
-    @patch('service.importRecord', side_effect=DataError('test err'))
+
+    @patch('service.DBManager')
     @patch('service.SessionManager')
-    def test_record_parse_write_err(self, mock_import, mock_manager):
+    def test_record_parse_write_err(self, mockManager, mockSession):
         testRec = base64.b64encode(json.dumps({
             'status': 200,
             'data': 'data'
         }).encode('utf-8'))
-        res = parseRecord({'kinesis': {'data': testRec}}, 'session')
+        mockManager.importRecord.side_effect = DataError('test err')
+        res = parseRecord({'kinesis': {'data': testRec}}, mockManager)
         self.assertNotEqual(res, True)
 
 

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, DEFAULT
 
 from helpers.errorHelpers import OutputError
 
@@ -134,3 +134,43 @@ class OutputTest(unittest.TestCase):
 
         testKey = MockOutputManager._createPartitionKey(testObj)
         self.assertEqual(testKey, '0')
+
+    @patch.multiple(OutputManager, _convertToJSON=DEFAULT, _createPartitionKey=DEFAULT)
+    def test_putKinesisBatch(self, _convertToJSON, _createPartitionKey):
+        _convertToJSON.return_value = 'jsonDict'
+        _createPartitionKey.return_value = 1
+        testManager = MockOutputManager()
+        testManager.putKinesisBatch([{'data': 'data', 'recType': 'test'}], 'testStream')
+        testManager.KINESIS_CLIENT.put_records.assert_called_once_with(
+            Records=[{'Data': 'jsonDict', 'PartitionKey': 1}],
+            StreamName='testStream'
+        )
+
+    @patch.multiple(OutputManager, _convertToJSON=DEFAULT, _createPartitionKey=DEFAULT)
+    def test_putKinesisBatch_error(self, _convertToJSON, _createPartitionKey):
+        _convertToJSON.return_value = 'jsonDict'
+        _createPartitionKey.return_value = 1
+        testManager = MockOutputManager()
+        testManager.KINESIS_CLIENT.put_records.side_effect = Exception
+
+        with self.assertRaises(OutputError):
+            testManager.putKinesisBatch([{'data': 'data', 'recType': 'test'}], 'testStream')
+
+    @patch.multiple(OutputManager, _convertToJSON=DEFAULT)
+    def test_putQueueBatches(self, _convertToJSON):
+        _convertToJSON.side_effect = ['dict1', 'dict2']
+        testManager = MockOutputManager()
+        testManager.putQueueBatches(['msg1', 'msg2'], 'testQueue')
+        testManager.SQS_CLIENT.send_message_batch.assert_called_once_with(
+            QueueUrl='testQueue',
+            Entries=[{'MessageBody': 'dict1', 'Id': 0}, {'MessageBody': 'dict2', 'Id': 1}]
+        )
+
+    @patch.multiple(OutputManager, _convertToJSON=DEFAULT)
+    def test_putQueueBatches_error(self, _convertToJSON):
+        _convertToJSON.return_value = 'jsonDict'
+        testManager = MockOutputManager()
+        testManager.SQS_CLIENT.send_message_batch.side_effect = Exception
+
+        with self.assertRaises(OutputError):
+            testManager.putQueueBatches(['msg1'], 'testQueue')

--- a/tests/test_query_manager.py
+++ b/tests/test_query_manager.py
@@ -68,24 +68,17 @@ class TestQueryManager(unittest.TestCase):
         self.assertEqual(testAgents, 'agent1')
 
     @patch.dict('os.environ', {'CLASSIFY_QUEUE': 'testQueue'})
-    @patch.multiple(OutputManager,
-                    checkRecentQueries=DEFAULT, putQueue=DEFAULT)
-    def test_createClassifyQuery_noCache(self, checkRecentQueries, putQueue):
+    @patch.multiple(OutputManager, checkRecentQueries=DEFAULT)
+    def test_createClassifyQuery_noCache(self, checkRecentQueries):
         testQuery = {
             'idType': 'testing',
             'identifier': '1'
         }
         checkRecentQueries.return_value = False
-        createClassifyQuery(testQuery, 'test', 'uuid')
+        outMsg = createClassifyQuery(testQuery, 'test', 'uuid')
         checkRecentQueries.assert_called_once_with('testing/1')
-        putQueue.assert_called_once_with(
-            {
-                'type': 'test',
-                'uuid': 'uuid',
-                'fields': testQuery
-            },
-            'testQueue'
-        )
+        self.assertEqual(outMsg['fields']['identifier'], '1')
+        self.assertEqual(outMsg['type'], 'test')
 
     @patch.dict('os.environ', {'CLASSIFY_QUEUE': 'testQueue'})
     @patch.multiple(OutputManager,


### PR DESCRIPTION
The database manager currently handles records in a fairly naive way, essentially treating each as an individual record without concern for potential performance issues that this may cause.

This update starts to combine some work done by the function into logical batches. In addition to some supporting improvements that both help reduce overhead and increase clarity in the output logs, the focus of this branch is on batching together requests to create kinesis records and SQS messages. By combining these and reducing the number of calls to these AWS services we can reduce the overall execution time of these functions from between 5-10%