### PR TITLE
HOTFIX Batch Message Output

### DIFF
--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -48,8 +48,8 @@ class DBManager:
         )
 
     def sendMessages(self):
-        for stream, records in self.kinesisMsgs.items():
+        for records, stream in self.kinesisMsgs.items():
             OutputManager.putKinesisBatch(stream, records)
 
-        for queue, messages in self.sqsMsgs.items():
+        for messages, queue in self.sqsMsgs.items():
             OutputManager.putQueueBatches(queue, messages)

--- a/service.py
+++ b/service.py
@@ -57,19 +57,21 @@ def parseRecords(records):
     logger.debug('Creating Session')
     session = MANAGER.createSession()
     dbManager = DBManager(session)
+    parseResults = []
     try:
-        parseResults = [parseRecord(r, dbManager) for r in records]
+        for r in records:
+            parseResults.append(parseRecord(r, dbManager))
         logger.debug('Parsed {} records. Committing results'.format(
             str(len(parseResults))
         ))
         MANAGER.closeConnection()
-        return parseResults
     except (NoRecordsReceived, DataError, DBError) as err:
         logger.error('Could not process records in current invocation')
         logger.debug(err)
         MANAGER.closeConnection()
 
     dbManager.sendMessages()
+    return parseResults
 
 
 def parseRecord(encodedRec, manager):

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -169,5 +169,5 @@ class TestDBManager(unittest.TestCase):
         testManager.sqsMsgs['testQueue'] = ['msg1', 'msg2', 'msg3']
 
         testManager.sendMessages()
-        putKinesisBatch.assert_called_with('testStream', ['rec1', 'rec2', 'rec3'])
-        putQueueBatches.assert_called_with('testQueue', ['msg1', 'msg2', 'msg3'])
+        putKinesisBatch.assert_called_with(['rec1', 'rec2', 'rec3'], 'testStream')
+        putQueueBatches.assert_called_with(['msg1', 'msg2', 'msg3'], 'testQueue')


### PR DESCRIPTION
The batch manager was taking the messages and stream/queue to write them to in a reversed form. This corrects the issue