### PR TITLE
Fix batch queue message index from integer to string

### DIFF
--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -112,7 +112,7 @@ class OutputManager():
                         'MessageBody': OutputManager._convertToJSON(
                             messages.pop()
                         ),
-                        'Id': i
+                        'Id': str(i)
                     })
                 except IndexError:
                     break

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -163,7 +163,7 @@ class OutputTest(unittest.TestCase):
         testManager.putQueueBatches(['msg1', 'msg2'], 'testQueue')
         testManager.SQS_CLIENT.send_message_batch.assert_called_once_with(
             QueueUrl='testQueue',
-            Entries=[{'MessageBody': 'dict1', 'Id': 0}, {'MessageBody': 'dict2', 'Id': 1}]
+            Entries=[{'MessageBody': 'dict1', 'Id': '0'}, {'MessageBody': 'dict2', 'Id': '1'}]
         )
 
     @patch.multiple(OutputManager, _convertToJSON=DEFAULT)


### PR DESCRIPTION
The AWS API expects the batch index keys for SQS messages to be strings, not integers as they currently are. This simply casts these to strings.