### PR TITLE
SFR-703 normalization

### DIFF
--- a/lib/importers/accessImporter.py
+++ b/lib/importers/accessImporter.py
@@ -30,6 +30,7 @@ class AccessReportImporter(AbstractImporter):
             return 'error'
 
         self.item = accessReport.item
+        self.session.add(accessReport)
         return 'insert'
 
     def setInsertTime(self):

--- a/lib/importers/instanceImporter.py
+++ b/lib/importers/instanceImporter.py
@@ -56,6 +56,8 @@ class InstanceImporter(AbstractImporter):
             self.session, self.data
         )
 
+        self.session.add(self.instance)
+
         self.storeCovers()
         self.storeEpubs(epubsToLoad)
 

--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -62,6 +62,8 @@ class ItemImporter(AbstractImporter):
 
         self.item = Item.createItem(self.session, self.data)
 
+        self.session.add(self.item)
+
         self.logger.debug('Got new item record, adding to instance')
         Instance.addItemRecord(self.session, instanceID, self.item)
 

--- a/lib/importers/workImporter.py
+++ b/lib/importers/workImporter.py
@@ -61,6 +61,9 @@ class WorkImporter(AbstractImporter):
     def insertRecord(self):
         self.work = Work(session=self.session)
         epubsToLoad = self.work.insert(self.data)
+
+        self.session.add(self.work)
+
         # Kicks off enhancement pipeline through OCLC CLassify
         queryMsgs = queryWork(self.session, self.work, self.work.uuid.hex)
         if len(queryMsgs) > 0:

--- a/tests/test_accessReport_importer.py
+++ b/tests/test_accessReport_importer.py
@@ -31,19 +31,23 @@ class TestAccessImporter(unittest.TestCase):
         mockReport = MagicMock()
         mockReport.item = 'testItem'
         mockAddData.return_value = mockReport
-        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
+        mockSession = MagicMock()
+        testImporter = AccessReportImporter({'data': {}}, mockSession, {}, {})
         testAction = testImporter.insertRecord()
         self.assertEqual(testAction, 'insert')
         self.assertEqual(testImporter.item, 'testItem')
-        mockAddData.assert_called_once_with('session', {})
+        mockAddData.assert_called_once_with(mockSession, {})
+        mockSession.add.assert_called_once_with(mockReport)
 
     @patch.object(Item, 'addReportData', return_value=None)
     def test_insertRecord_failure(self, mockAddData):
-        testImporter = AccessReportImporter({'data': {}}, 'session', {}, {})
+        mockSession = MagicMock()
+        testImporter = AccessReportImporter({'data': {}}, mockSession, {}, {})
         testAction = testImporter.insertRecord()
         self.assertEqual(testAction, 'error')
         self.assertEqual(testImporter.item, None)
-        mockAddData.assert_called_once_with('session', {})
+        mockAddData.assert_called_once_with(mockSession, {})
+        mockSession.add.assert_not_called()
 
     @patch('lib.importers.accessImporter.datetime')
     def test_setInsertTime(self, mockUTC):

--- a/tests/test_instance_importer.py
+++ b/tests/test_instance_importer.py
@@ -47,23 +47,26 @@ class TestInstanceImporter(unittest.TestCase):
     @patch.object(Instance, 'createNew')
     @patch.multiple(InstanceImporter, storeCovers=DEFAULT, storeEpubs=DEFAULT)
     def test_insertRecord(self, mockCreate, storeCovers, storeEpubs):
-        testImporter = InstanceImporter({'data': {}}, 'session', {}, {})
+        mockSession = MagicMock()
+        testImporter = InstanceImporter({'data': {}}, mockSession, {}, {})
         mockInstance = MagicMock()
         mockCreate.return_value = (mockInstance, ['epub1'])
         testImporter.insertRecord()
         self.assertEqual(testImporter.instance, mockInstance)
         storeCovers.assert_called_once()
         storeEpubs.assert_called_once_with(['epub1'])
+        mockSession.add.assert_called_once_with(mockInstance)
 
     @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
     def test_storeCovers_dictFlags(self):
+        mockSession = MagicMock()
         testImporter = InstanceImporter(
             {
                 'data': {
                     'identifiers': [{'identifier': 1}]
                 }
             },
-            'session',
+            mockSession,
             defaultdict(list), defaultdict(list)
         )
         mockInstance = MagicMock()

--- a/tests/test_item_importer.py
+++ b/tests/test_item_importer.py
@@ -47,11 +47,13 @@ class TestItemImporter(unittest.TestCase):
     @patch.object(Item, 'createItem')
     @patch.object(Instance, 'addItemRecord')
     def test_insertRecord(self, mockAddItem, mockCreate):
-        testImporter = ItemImporter({'data': {}}, 'session', {}, {})
+        mockSession = MagicMock()
+        testImporter = ItemImporter({'data': {}}, mockSession, {}, {})
         mockCreate.return_value = 'testItem'
         testImporter.insertRecord()
         self.assertEqual(testImporter.item, 'testItem')
-        mockAddItem.assert_called_once_with('session', None, 'testItem')
+        mockAddItem.assert_called_once_with(mockSession, None, 'testItem')
+        mockSession.add.assert_called_once_with('testItem')
 
     @patch('lib.importers.itemImporter.datetime')
     def test_setInsertTime(self, mockUTC):

--- a/tests/test_work_importer.py
+++ b/tests/test_work_importer.py
@@ -77,8 +77,9 @@ class TestWorkImporter(unittest.TestCase):
     @patch('lib.importers.workImporter.queryWork')
     def test_insertRecord(self, mockQuery, insert, uuid, storeCovers,
                           storeEpubs):
+        mockSession = MagicMock()
         testImporter = WorkImporter(
-            {'data': {}}, 'session', defaultdict(list), defaultdict(list))
+            {'data': {}}, mockSession, defaultdict(list), defaultdict(list))
         insert.return_value = ['epub1']
         mockQuery.return_value = ['testQueryMessage']
         testImporter.insertRecord()
@@ -89,6 +90,7 @@ class TestWorkImporter(unittest.TestCase):
         self.assertEqual(
             testImporter.sqsMsgs['testQueue'][0], 'testQueryMessage'
         )
+        mockSession.add.assert_called_once()
 
     @patch.dict('os.environ', {'COVER_QUEUE': 'test_queue'})
     def test_storeCovers_strFlags(self):


### PR DESCRIPTION
This brings the db-manager in line with the changes already made to the db-updater function. Importantly this makes sure all updated objects are explicitly added to the session and that any integrity errors (mainly unique constraint violations are caught and handled.)