### PR TITLE
HOTFIX Remove LCCN from Classify queries

### DIFF
--- a/lib/queryManager.py
+++ b/lib/queryManager.py
@@ -19,14 +19,12 @@ LOOKUP_IDENTIFIERS = [
     'oclc',   # OCLC Number
     'isbn',   # ISBN (10 or 13)
     'issn',   # ISSN
-    'lccn',   # LCCN
     'swid',   # OCLC Work Identifier
 ]
 
 IDENTIFIER_TYPES = {
         'oclc': OCLC,
         'swid': OWI,
-        'lccn': LCCN,
         'isbn': ISBN,
         'issn': ISSN,
     }

--- a/tests/test_query_manager.py
+++ b/tests/test_query_manager.py
@@ -44,12 +44,11 @@ class TestQueryManager(unittest.TestCase):
         mockSession.query().join().filter().all.side_effect = [
             [],
             [],
-            [],
             [(1,), (2,), (3,)],
             []
         ]
         testIdentifiers = getIdentifiers(mockSession, MagicMock())
-        self.assertEqual(testIdentifiers, {'lccn': [1, 2, 3]})
+        self.assertEqual(testIdentifiers, {'issn': [1, 2, 3]})
 
     def test_getAuthors(self):
         mockRel1 = MagicMock()


### PR DESCRIPTION
This removes LCCN as an option for making Classify queries from the manager. These queries would frequently return "multi-work" responses from the Classify API that were incorrect. Either associating multiple works by the same author or even returning results for multiple completely unrelated works. While at first glance this would seem to be an issue with metadata, this does not seem to be the problem, but instead an internal issue with the Classify API itself. LCCN is not documented as a option in the public GUI options for this service, but is present in the API documentation, which makes it seem as though its an experimental or not fully supported function.