### PR TITLE
HOTFIX Handle internal psycopg2 errors

### DIFF
--- a/lib/importers/itemImporter.py
+++ b/lib/importers/itemImporter.py
@@ -63,6 +63,7 @@ class ItemImporter(AbstractImporter):
         self.item = Item.createItem(self.session, self.data)
 
         self.session.add(self.item)
+        self.session.add_all(self.item.links)
 
         self.logger.debug('Got new item record, adding to instance')
         Instance.addItemRecord(self.session, instanceID, self.item)

--- a/tests/test_item_importer.py
+++ b/tests/test_item_importer.py
@@ -48,12 +48,13 @@ class TestItemImporter(unittest.TestCase):
     @patch.object(Instance, 'addItemRecord')
     def test_insertRecord(self, mockAddItem, mockCreate):
         mockSession = MagicMock()
+        mockItem = MagicMock()
         testImporter = ItemImporter({'data': {}}, mockSession, {}, {})
-        mockCreate.return_value = 'testItem'
+        mockCreate.return_value = mockItem
         testImporter.insertRecord()
-        self.assertEqual(testImporter.item, 'testItem')
-        mockAddItem.assert_called_once_with(mockSession, None, 'testItem')
-        mockSession.add.assert_called_once_with('testItem')
+        self.assertEqual(testImporter.item, mockItem)
+        mockAddItem.assert_called_once_with(mockSession, None, mockItem)
+        mockSession.add.assert_called_once_with(mockItem)
 
     @patch('lib.importers.itemImporter.datetime')
     def test_setInsertTime(self, mockUTC):


### PR DESCRIPTION
These fixes handle a few internal database issues that were causing issues with the import process. None of these issues were causing side effects but did prevent certain records from being imported. These are:

- Specific handling for `ProgramLimitExceeded` errors, which indicate that a record was not processed properly by the source reader. These cannot be retryed. The model implemented here may be added for other internal database errors as they are encountered.
- Additional session adds for link objects to ensure that the ORM updates are pushed to the database.
- Slight increase in test coverage to add these changes